### PR TITLE
🐧 Bump Alpine to v3.23.4 - 260418

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############################
 # 1) Build ocserv
 ############################
-FROM alpine:3.23.3 AS ocserv-build
+FROM alpine:3.23.4 AS ocserv-build
 
 ARG OCSERV_VERSION=1.4.1
 
@@ -35,7 +35,7 @@ RUN set -eux && \
 ############################
 # 2) Fetch s6-overlay (arch-aware)
 ############################
-FROM alpine:3.23.3 AS s6-fetch
+FROM alpine:3.23.4 AS s6-fetch
 
 ARG TARGETARCH
 ARG TARGETVARIANT
@@ -81,7 +81,7 @@ RUN echo "**** install security fix packages ****" && \
 ############################
 # 3) Assemble rootfs (apply perms here)
 ############################
-FROM alpine:3.23.3 AS rootfs
+FROM alpine:3.23.4 AS rootfs
 
 RUN mkdir -p /rootfs
 
@@ -98,7 +98,7 @@ COPY --from=ocserv-build /pkg/    /rootfs/
 ############################
 # 4) Final runtime (minimal layers)
 ############################
-FROM alpine:3.23.3
+FROM alpine:3.23.4
 
 ARG IMAGE_VERSION=N/A \
     BUILD_DATE=N/A \
@@ -124,7 +124,7 @@ RUN apk --no-cache --no-progress add \
     libev=4.33-r1 \
     lz4-libs=1.10.0-r0 \
     protobuf-c=1.5.2-r2 \
-    ca-certificates=20251003-r0 \
+    ca-certificates=20260413-r0 \
     shadow=4.18.0-r0 \
     libcap=2.78-r0 \
     iptables=1.8.11-r1 \

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ docker build -t ocserv-server .
 
 ## Architecture
 
-- **Base**: Alpine Linux 3.23.3
+- **Base**: Alpine Linux 3.23.4
 - **Init**: s6-overlay 3.2.2.0
 - **VPN**: ocserv 1.4.1
 - **Networking**: iptables with NAT support


### PR DESCRIPTION
## 🐧 Alpine Base Image Update

**File**: `Dockerfile`
**Date**: 260418
**Source**: Docker Hub `library/alpine` tags

### Change
- Current: `3.23.3`
- New: `3.23.4`

This PR updates all `FROM alpine:*` lines to the latest stable Alpine tag and updates version references in README.md.

---
🤖 Auto-generated by [update-alpine workflow](https://github.com/azinchen/ocserv-server/actions/workflows/maintenance-updates.yml)