### PR TITLE
🔄 Bump ocserv to v1.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ############################
 FROM alpine:3.23.3 AS ocserv-build
 
-ARG OCSERV_VERSION=1.4.1
+ARG OCSERV_VERSION=1.4.2
 
 RUN set -eux && \
     apk --no-cache --no-progress add \
@@ -102,7 +102,7 @@ FROM alpine:3.23.3
 
 ARG IMAGE_VERSION=N/A \
     BUILD_DATE=N/A \
-    OCSERV_VERSION=1.4.1
+    OCSERV_VERSION=1.4.2
 
 LABEL org.opencontainers.image.title="OpenConnect VPN Server (ocserv) Docker container" \
       org.opencontainers.image.description="OpenConnect VPN Server (ocserv) in a Docker container with s6-overlay" \

--- a/README.md
+++ b/README.md
@@ -117,5 +117,5 @@ docker build -t ocserv-server .
 
 - **Base**: Alpine Linux 3.23.3
 - **Init**: s6-overlay 3.2.2.0
-- **VPN**: ocserv 1.4.1
+- **VPN**: ocserv 1.4.2
 - **Networking**: iptables with NAT support


### PR DESCRIPTION
## 🔄 Ocserv Version Update

**Repository**: [openconnect/ocserv](https://gitlab.com/openconnect/ocserv)
**Version**: `1.4.2`

This PR updates the ocserv version in the Dockerfile.

### Changes:
- Updated `OCSERV_VERSION` ARG in Dockerfile
- Updated version reference in README.md
- Bumped from previous version to `1.4.2`

---
🤖 Auto-generated by [maintenance-updates workflow](https://github.com/azinchen/ocserv-server/actions/workflows/maintenance-updates.yml)