### PR TITLE
📋 Bump s6-overlay to v3.2.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ARG TARGETARCH
 ARG TARGETVARIANT
 
 ENV PACKAGE="just-containers/s6-overlay"
-ENV PACKAGEVERSION="3.2.2.0"
+ENV PACKAGEVERSION="3.2.3.0"
 
 RUN echo "**** install security fix packages ****" && \
     echo "**** install mandatory packages ****" && \

--- a/README.md
+++ b/README.md
@@ -116,6 +116,6 @@ docker build -t ocserv-server .
 ## Architecture
 
 - **Base**: Alpine Linux 3.23.4
-- **Init**: s6-overlay 3.2.2.0
+- **Init**: s6-overlay 3.2.3.0
 - **VPN**: ocserv 1.4.2
 - **Networking**: iptables with NAT support


### PR DESCRIPTION
## 📋 Package Version Update

**Repository**: [just-containers/s6-overlay](https://github.com/just-containers/s6-overlay)
**Version**: `3.2.3.0`

This PR updates the package version in the Dockerfile.

### Changes:
- Updated `PACKAGEVERSION` environment variable in Dockerfile
- Updated version reference in README.md
- Bumped from previous version to `3.2.3.0`

---
🤖 Auto-generated by [update-packages workflow](https://github.com/azinchen/ocserv-server/actions/workflows/maintenance-updates.yml)