### PR TITLE
🔄 Bump ocserv to v1.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ############################
 FROM alpine:3.23.4 AS ocserv-build
 
-ARG OCSERV_VERSION=1.4.2
+ARG OCSERV_VERSION=1.5.0
 
 RUN set -eux && \
     apk --no-cache --no-progress add \
@@ -102,7 +102,7 @@ FROM alpine:3.23.4
 
 ARG IMAGE_VERSION=N/A \
     BUILD_DATE=N/A \
-    OCSERV_VERSION=1.4.2
+    OCSERV_VERSION=1.5.0
 
 LABEL org.opencontainers.image.title="OpenConnect VPN Server (ocserv) Docker container" \
       org.opencontainers.image.description="OpenConnect VPN Server (ocserv) in a Docker container with s6-overlay" \

--- a/README.md
+++ b/README.md
@@ -117,5 +117,5 @@ docker build -t ocserv-server .
 
 - **Base**: Alpine Linux 3.23.4
 - **Init**: s6-overlay 3.2.3.0
-- **VPN**: ocserv 1.4.2
+- **VPN**: ocserv 1.5.0
 - **Networking**: iptables with NAT support


### PR DESCRIPTION
## 🔄 Ocserv Version Update

**Repository**: [openconnect/ocserv](https://gitlab.com/openconnect/ocserv)
**Version**: `1.5.0`

This PR updates the ocserv version in the Dockerfile.

### Changes:
- Updated `OCSERV_VERSION` ARG in Dockerfile
- Updated version reference in README.md
- Bumped from previous version to `1.5.0`

---
🤖 Auto-generated by [maintenance-updates workflow](https://github.com/azinchen/ocserv-server/actions/workflows/maintenance-updates.yml)