### PR TITLE
fix: allow musl mallocng syscalls in ocserv worker seccomp filter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ FROM alpine:${ALPINE_VERSION} AS ocserv-build
 
 ARG OCSERV_VERSION=1.5.0
 
+COPY patches/ /tmp/patches/
+
 RUN set -eux && \
     apk --no-cache --no-progress add \
         build-base=0.5-r4 \
@@ -27,10 +29,12 @@ RUN set -eux && \
         curl=8.20.0-r1 \
         tar=1.35-r5 \
         xz=5.8.3-r0 \
+        patch=2.8-r0 \
         && \
     curl -fsSL "https://www.infradead.org/ocserv/download/ocserv-${OCSERV_VERSION}.tar.xz" -o /tmp/ocserv.tar.xz && \
     tar -C /tmp -xf /tmp/ocserv.tar.xz && \
     cd /tmp/ocserv-* && \
+    for p in /tmp/patches/*.patch; do echo "Applying patch ${p}" && patch -p1 < "${p}"; done && \
     meson setup builddir --prefix=/usr --sysconfdir=/etc/ocserv --localstatedir=/var --buildtype=release && \
     ninja -C builddir && \
     DESTDIR=/pkg meson install -C builddir --no-rebuild && \

--- a/patches/0001-worker-privs-allow-musl-mallocng-syscalls.patch
+++ b/patches/0001-worker-privs-allow-musl-mallocng-syscalls.patch
@@ -1,0 +1,15 @@
+--- a/src/worker-privs.c
++++ b/src/worker-privs.c
+@@ -137,6 +137,12 @@
+ 	/* memory allocation - both are used by different platforms */
+ 	ADD_SYSCALL(brk, 0);
+ 	ADD_SYSCALL(mmap, 0);
++	/* musl's mallocng releases/reshapes mappings during normal alloc/free
++	 * churn; blocking these makes the allocator return NULL under load and
++	 * GnuTLS treats that as a fatal allocation failure (worker crash). */
++	ADD_SYSCALL(munmap, 0);
++	ADD_SYSCALL(mremap, 0);
++	ADD_SYSCALL(madvise, 0);
+
+ #if defined(SYS_getrandom) || defined(__NR_getrandom)
+ 	ADD_SYSCALL(getrandom, 0); /* used by gnutls 3.5.x */


### PR DESCRIPTION
## Summary

ocserv 1.5.0's worker seccomp allowlist (`src/worker-privs.c`) omits `munmap`, `mremap` and `madvise`. Under load, musl's mallocng releases/reshapes mappings during normal alloc/free churn, so blocking these syscalls makes the allocator return `NULL` — and GnuTLS treats that as a fatal allocation failure, crashing the worker.

## Changes

- Add a `patches/` directory that is copied into the build stage and applied (`patch -p1`) to the ocserv source before `meson setup`. The build loops over `patches/*.patch`, so future patches need no Dockerfile change.
- `0001-worker-privs-allow-musl-mallocng-syscalls.patch` extends the worker seccomp allowlist with `munmap`, `mremap` and `madvise`.
- Add `patch=2.8-r0` to the build-stage apk deps (pin verified against the Alpine 3.24 repo).

The `patches/` dir lands in the build stage only and is not present in the final image.