### PR TITLE
ci: replace wiki submodule with in-repo folder synced by workflow

### DIFF
--- a/.github/workflows/wiki-publish.yml
+++ b/.github/workflows/wiki-publish.yml
@@ -22,12 +22,8 @@ jobs:
       - name: Determine published version
         id: version
         run: |
-          if [ "${{ github.ref_type }}" = "tag" ]; then
-            VERSION="${{ github.ref_name }}"
-          else
-            SHORT_SHA="$(git rev-parse --short HEAD)"
-            VERSION="${{ github.ref_name }}@${SHORT_SHA}"
-          fi
+          # The tag or branch the workflow runs on (push tag or dispatch ref)
+          VERSION="${{ github.ref_name }}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "Publishing wiki for version: ${VERSION}"
 

--- a/.github/workflows/wiki-publish.yml
+++ b/.github/workflows/wiki-publish.yml
@@ -1,0 +1,62 @@
+name: Docs - Publish Wiki
+
+on:
+  push:
+    # Publish on every release (tag) push
+    tags: [ '**' ]
+  workflow_dispatch:
+    # Manual publish from any branch or tag
+
+permissions:
+  contents: write  # Required to push to the wiki repository
+
+jobs:
+  publish-wiki:
+    name: 📚 Publish Wiki
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Determine published version
+        id: version
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            VERSION="${{ github.ref_name }}"
+          else
+            SHORT_SHA="$(git rev-parse --short HEAD)"
+            VERSION="${{ github.ref_name }}@${SHORT_SHA}"
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Publishing wiki for version: ${VERSION}"
+
+      - name: Clone wiki repository
+        run: |
+          git clone "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.wiki.git" wiki-repo
+
+      - name: Sync wiki content
+        run: |
+          # Replace/add/delete: make the wiki repo mirror the wiki/ folder exactly
+          rsync -av --delete --exclude '.git' wiki/ wiki-repo/
+
+      - name: Commit and push
+        working-directory: wiki-repo
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No wiki changes - pushing empty marker commit"
+            git commit --allow-empty -m "Publish wiki for ${{ steps.version.outputs.version }} (no content changes)"
+          else
+            git commit -m "Publish wiki for ${{ steps.version.outputs.version }}"
+          fi
+
+          git push origin HEAD:master
+
+      - name: Publish summary
+        run: |
+          echo "✅ Wiki published for version ${{ steps.version.outputs.version }}"
+          echo "   https://github.com/${{ github.repository }}/wiki"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "wiki"]
-	path = wiki
-	url = git@github.com:azinchen/ocserv-server.wiki.git

--- a/wiki/Architecture-and-Internals.md
+++ b/wiki/Architecture-and-Internals.md
@@ -1,0 +1,76 @@
+# Architecture and Internals
+
+How the image is built and what happens when the container starts.
+
+## Stack
+
+| Layer | What |
+|---|---|
+| Base | Alpine Linux |
+| Init / supervisor | s6-overlay |
+| VPN | ocserv (built from source) |
+| Firewall backend | nftables (`nft`) |
+| Build system | Meson + Ninja |
+
+## Multi-stage build
+
+The `Dockerfile` uses several stages so the final image stays small and contains no build tooling:
+
+1. **`ocserv-build`** — installs build deps and compiles ocserv from the upstream tarball with **Meson/Ninja**. Built with the **nftables** firewall-script backend. Installs into a staging prefix (`/pkg`). The bundled default `ocserv.conf` template is derived from ocserv's `doc/sample.config` with certificate paths normalized to `/etc/ocserv/...`.
+2. **`s6-fetch`** — downloads the architecture-appropriate s6-overlay release tarballs (it maps Docker's `TARGETARCH` to s6's arch names, so the image is multi-arch).
+3. **`rootfs`** — assembles the container root filesystem: the project's `rootfs/` overlay (s6 service definitions, helper scripts), the s6-overlay files, and the compiled ocserv from `/pkg`. Permissions are normalized here.
+4. **Final runtime** — Alpine + just the runtime libraries (gnutls, libev, nftables, etc.), then the assembled rootfs copied in. `ENTRYPOINT` is s6's `/init`.
+
+Pinned, reproducible apk versions are used throughout. The base image and package versions are kept current by a maintenance workflow (see [[Building and CI]]).
+
+## Startup: the s6 service graph
+
+s6-overlay runs the service tree under `/etc/s6-overlay/s6-rc.d`. Three services matter:
+
+```
+init-config ─┐
+             ├─► svc-ocserv   (longrun)
+init-nat ────┘
+```
+
+### init-config
+
+Oneshot. Ensures `/etc/ocserv/ocserv.conf` exists — if it's missing, it copies the bundled template into place. Your own mounted config is never overwritten.
+
+### init-nat
+
+Oneshot. Prepares networking:
+
+- Enables IPv4 forwarding (and IPv6 forwarding if `IPV6_FORWARD=1`). If IPv4 forwarding can't be enabled, it logs guidance and stops (the container needs the `ip_forward` sysctl).
+- Installs the `table inet ocserv` nftables rules: a forward chain for the tunnel interface and a postrouting masquerade for `VPN_SUBNET` via `WAN_IF`. Optionally IPv6 masquerade when `IPV6_NAT=1`. See [[Networking NAT and Routing]].
+
+### svc-ocserv
+
+Longrun, depends on both oneshots. Creates runtime dirs (`/run/ocserv`, …) and execs:
+
+```
+ocserv --foreground --config /etc/ocserv/ocserv.conf --log-stderr
+```
+
+Logs go to the container's stdout/stderr, so `docker logs` shows everything.
+
+## Configuration knobs are centralized
+
+All env-var defaults live in one helper, `/usr/local/bin/backend-functions`, which the service scripts source. That's where `VPN_SUBNET`, `WAN_IF`, `VPN_IF`, `IPV6_*` defaults and the logging helpers are defined. See [[Configuration Reference]].
+
+## Filesystem map
+
+| Path | Role |
+|---|---|
+| `/etc/ocserv/ocserv.conf` | Main config (your volume) |
+| `/etc/ocserv/ocpasswd` | User database (your volume) |
+| `/usr/share/ocserv/ocserv.conf.template` | Bundled default config |
+| `/usr/sbin/ocserv`, `/usr/sbin/ocserv-worker` | The server |
+| `/usr/bin/occtl`, `/usr/bin/ocpasswd` | Control + user tools |
+| `/usr/libexec/ocserv-fw` | Per-user firewall helper (nftables) |
+| `/run/ocserv/` | PID + control sockets |
+| `/swag-config/` | Optional read-only SWAG certs |
+
+---
+
+Next: **[[Building and CI]]** · **[[Troubleshooting]]**

--- a/wiki/Building-and-CI.md
+++ b/wiki/Building-and-CI.md
@@ -1,0 +1,57 @@
+# Building and CI
+
+## Build it yourself
+
+```bash
+git clone https://github.com/azinchen/ocserv-server.git
+cd ocserv-server
+docker build -t ocserv-server:local .
+```
+
+The build compiles ocserv from source with Meson/Ninja and assembles the rootfs — see [Architecture and Internals#multi-stage-build](Architecture-and-Internals#multi-stage-build). No special build args are required; ocserv and dependency versions are pinned in the `Dockerfile`.
+
+Run your locally built image by swapping the image name in your compose file for `ocserv-server:local`, or use the repo's root `docker-compose.yml`, which has `build: .`.
+
+## Published images & tags
+
+Images are published by GitHub Actions:
+
+| Tag | Source | Registry |
+|---|---|---|
+| `:dev` | the `main` branch | GHCR — `ghcr.io/azinchen/ocserv-server:dev` |
+| `:<branch>` | other branches (sanitized name) | GHCR |
+| `:<version>` and `:latest` | git release tags | GHCR **and** Docker Hub — `azinchen/ocserv-server` |
+
+So:
+
+- **Latest development build:** `ghcr.io/azinchen/ocserv-server:dev`
+- **Latest release:** `azinchen/ocserv-server:latest` (or pin a specific `:x.y.z`)
+
+Development builds (branches, `main`) are built for `linux/amd64` for speed; release builds are multi-arch.
+
+## Pulling the newest dev image
+
+```bash
+docker compose pull && docker compose up -d
+# or
+docker pull ghcr.io/azinchen/ocserv-server:dev
+```
+
+## Dependency & version maintenance
+
+- **Base image, apk package versions, and the ocserv version** are bumped by a custom maintenance workflow (`maintenance-updates.yml`) which opens `bot/update-*` branches.
+- **GitHub Actions** are kept current by Dependabot (scoped to `github-actions` only — Docker/base-image updates are handled by the maintenance workflow, not Dependabot).
+
+## Validating a config in CI-like fashion
+
+Use the bundled config tester against any config before deploying:
+
+```bash
+docker run --rm -v ./volumes/config:/etc/ocserv:ro \
+  --entrypoint /usr/sbin/ocserv ghcr.io/azinchen/ocserv-server:dev \
+  -t -c /etc/ocserv/ocserv.conf
+```
+
+---
+
+Next: **[[Troubleshooting]]** · **[[FAQ]]**

--- a/wiki/Camouflage-Mode.md
+++ b/wiki/Camouflage-Mode.md
@@ -1,0 +1,64 @@
+# Camouflage Mode
+
+Camouflage makes the VPN server **look like an ordinary HTTPS website** to anyone who probes it. Without the correct secret, the server responds like a normal (or password-protected) web server and never reveals that a VPN is listening. This helps bypass deep packet inspection (DPI), active probing, and censorship that blocks recognizable VPN endpoints.
+
+## How it works
+
+When `camouflage = true`, ocserv only begins the VPN handshake if the client's request URL carries the right secret. Anything else gets a generic web response:
+
+- A probe **without** the secret → looks like a plain web server. If `camouflage_realm` is set, it returns an HTTP `401` Basic-auth challenge — i.e. it looks like a password-protected site.
+- A request **with** the correct secret → the VPN handshake proceeds normally (`200`).
+
+Because all of this rides on a normal TLS connection to port 443 with a valid certificate, on the wire it is hard to distinguish from regular HTTPS browsing.
+
+## Configuration
+
+```ini
+camouflage = true
+camouflage_secret = "a-long-random-hard-to-guess-secret"
+camouflage_realm  = "Restricted Content"
+```
+
+- **`camouflage_secret`** — the shared secret clients must present. Treat it like a password: long and random. (32+ characters recommended.)
+- **`camouflage_realm`** — optional. When set, probes get a `401` with this realm, mimicking a protected site. Omit it to instead mimic a generic `404`-style server.
+
+## Connecting with the secret
+
+Clients append the secret to the connection URL after a `?`:
+
+```
+https://vpn.example.com:8443/?a-long-random-hard-to-guess-secret
+```
+
+With the `openconnect` client:
+
+```bash
+sudo openconnect "https://vpn.example.com:8443/?a-long-random-hard-to-guess-secret" --user=alice
+```
+
+For AnyConnect and router clients (e.g. Keenetic / Netcraze), put the full URL **including `/?secret`** in the server address field. See [[Clients and Devices]].
+
+## Verifying camouflage works
+
+From any machine:
+
+```bash
+# Without the secret — should look like a normal/protected web server (e.g. 401 or 404)
+curl -s -o /dev/null -w "%{http_code}\n" https://vpn.example.com:8443/
+
+# With the secret — VPN endpoint responds (200)
+curl -s -o /dev/null -w "%{http_code}\n" "https://vpn.example.com:8443/?your-secret"
+```
+
+A result of `401` (or `404`) without the secret and `200` with it confirms camouflage is active.
+
+## Notes & good practice
+
+- **Use a real, trusted certificate** (Let's Encrypt via [SWAG](Reverse-Proxy-and-Certificates)). A self-signed cert is itself a tell that something non-standard is running.
+- **TCP-only is stealthier.** DTLS over UDP to port 443 is unusual traffic and weakens the disguise; many camouflage deployments disable DTLS. See [Configuration Reference#ports](Configuration-Reference#ports).
+- **Rotate the secret** if you suspect it leaked; update `camouflage_secret` and restart.
+- The secret appears in the URL — keep client configs private.
+
+---
+
+Next: **[[Reverse Proxy and Certificates]]** · **[[Clients and Devices]]**

--- a/wiki/Clients-and-Devices.md
+++ b/wiki/Clients-and-Devices.md
@@ -1,0 +1,66 @@
+# Clients and Devices
+
+ocserv speaks the OpenConnect / Cisco AnyConnect SSL-VPN protocol, so a wide range of clients work. The connection target is your server URL — **including the camouflage secret** if [camouflage](Camouflage-Mode) is enabled.
+
+> If camouflage is on, every example below must use `https://host:port/?your-secret` as the server URL.
+
+## OpenConnect (Linux / macOS / BSD)
+
+```bash
+# Trusted (Let's Encrypt) cert
+sudo openconnect https://vpn.example.com:8443 --user=alice
+
+# With camouflage secret
+sudo openconnect "https://vpn.example.com:8443/?your-secret" --user=alice
+
+# Self-signed cert — pin it instead of disabling verification
+FPRINT=$(openssl x509 -noout -fingerprint -sha256 -in server-cert.pem | cut -d= -f2 | tr -d ':')
+sudo openconnect --servercert "sha256:$FPRINT" https://SERVER_IP --user=alice
+
+# Non-interactive password
+echo 'S3cret' | sudo openconnect https://vpn.example.com:8443 --user=alice --passwd-on-stdin
+```
+
+## Cisco AnyConnect
+
+- **Server address:** `https://vpn.example.com:8443/?your-secret`
+- **Username / password:** from your `ocpasswd` users
+- Enabled server-side by `cisco-client-compat = true` (already set in the samples).
+
+## Mobile (iOS / Android)
+
+Use the official **OpenConnect** app (or Cisco Secure Client / AnyConnect):
+
+- Add a connection with the server URL (with the secret if camouflaging).
+- Enter username/password.
+- A trusted certificate avoids manual "untrusted cert" prompts.
+
+## Keenetic and Netcraze routers
+
+Keenetic supports OpenConnect as a client. **Netcraze** routers are the same hardware/firmware family rebranded for different markets, so everything here applies to them identically. Notes specific to routers:
+
+- Put the **full URL including `/?your-secret`** in the connection's server field.
+- Username/password from `ocpasswd`.
+- **TCP-only works well** with this image's recommended setup (DTLS/UDP is often disabled — see [Configuration Reference#ports](Configuration-Reference#ports)).
+
+### Routing the router's traffic through the VPN
+
+A connected tunnel does **not** automatically send the router's LAN traffic through the VPN. By default these routers keep their ISP as the default route. To actually use the VPN for traffic you configure **connection priorities / policy-based routing** on the router:
+
+- **Per-device policy (recommended for testing):** create a connection-priority profile that uses the OpenConnect connection and assign just one test device to it. Everything else keeps the ISP.
+- **Full tunnel for everyone:** raise the VPN above the ISP in the internet-connection priority list.
+
+This is a router-side decision — the server already advertises `route = default`. See [Networking NAT and Routing#full-vs-split-tunnel](Networking-NAT-and-Routing#full-vs-split-tunnel).
+
+## Confirming a client really works
+
+Authenticating is not the same as carrying traffic. After connecting:
+
+- From the client (or the router's diagnostics/ping tool), ping the VPN gateway: `10.20.0.1` (your `ipv4-network` .1). A reply proves the tunnel data path.
+- Then ping a public IP, e.g. `1.1.1.1`, to prove routing + NAT end-to-end.
+
+Watch it from the server side — see [Troubleshooting#how-do-i-prove-the-tunnel-actually-works](Troubleshooting#how-do-i-prove-the-tunnel-actually-works).
+
+---
+
+Next: **[[Troubleshooting]]** · **[[Architecture and Internals]]**

--- a/wiki/Configuration-Reference.md
+++ b/wiki/Configuration-Reference.md
@@ -1,0 +1,64 @@
+# Configuration Reference
+
+Everything you configure at the **container** level: environment variables, volumes, ports, capabilities, and sysctls. (The VPN's own behaviour lives in `ocserv.conf` — see [[ocserv Configuration]].)
+
+## Environment variables
+
+These are read by the container's startup scripts (`backend-functions`) and drive the automatic NAT/forwarding setup. Defaults are the in-image defaults.
+
+| Variable | Default | Description |
+|---|---|---|
+| `VPN_SUBNET` | `10.10.10.0/24` | IPv4 subnet that gets source-NAT (masquerade) out of the WAN interface. **Must match the `ipv4-network`/`ipv4-netmask` in your `ocserv.conf`.** |
+| `WAN_IF` | `eth0` | The container interface used as the NAT egress (the "outside"). |
+| `VPN_IF` | `vpns+` | Interface pattern for the tun devices ocserv creates. The trailing `+` is translated to the nftables wildcard `vpns*`. Matches `device = vpns` in `ocserv.conf`. |
+| `IPV6_FORWARD` | `1` | Enable IPv6 forwarding sysctl inside the container. |
+| `IPV6_NAT` | `0` | Enable IPv6 masquerade for `IPV6_SUBNET`. Off by default — see the IPv6 warning below. |
+| `IPV6_SUBNET` | `fda9:4efe:7e3b:03ea::/64` | IPv6 ULA subnet to masquerade when `IPV6_NAT=1`. |
+| `VPN_GATEWAY` | _(unset)_ | Route the client subnet out through an upstream gateway container (e.g. a NordVPN container) instead of straight out the WAN. Set to the gateway's IP. Adds a fail-closed kill switch. See [[Gateway Mode]]. |
+| `VPN_GATEWAY6` | _(unset)_ | Upstream IPv6 gateway. Set to route the IPv6 client subnet through it; unset means forwarded client IPv6 is dropped. See [[Gateway Mode]]. |
+| `VPN_GATEWAY_TABLE` | `100` | Routing table used for the gateway default route. |
+| `VPN_GATEWAY_RULE_PRIO` | `1000` | Priority of the `from <VPN_SUBNET>` policy rule. |
+
+> **About `PUID`/`PGID`:** this image does **not** implement LinuxServer-style `PUID`/`PGID` user remapping. Setting them has no effect; ocserv drops privileges internally via the `run-as-user`/`run-as-group` directives in `ocserv.conf`.
+
+### ⚠️ IPv6 caveat
+
+Do **not** advertise an IPv6 default route (`route = ::/0`) to clients unless the container actually has working IPv6 egress. By default the Docker bridge has no IPv6 and `IPV6_NAT=0`, so handing clients an IPv6 address + `::/0` route **blackholes their IPv6 traffic** (connections hang until they time out and fall back to IPv4).
+
+The maintained samples ship IPv6 **off** for this reason. To enable it properly you need (1) Docker IPv6 networking on the container's network and (2) `IPV6_NAT=1`. See [Networking NAT and Routing#ipv6](Networking-NAT-and-Routing#ipv6).
+
+## Volumes
+
+| Mount | Purpose |
+|---|---|
+| `/etc/ocserv` | **Required.** Holds `ocserv.conf`, the `ocpasswd` user database, and any certificates you place there. Persist this. |
+| `/swag-config` (read-only) | Optional. Mount a SWAG config directory here to use its Let's Encrypt certs directly. See [[Reverse Proxy and Certificates]]. |
+| `/etc/localtime`, `/etc/timezone` (read-only) | Optional. Align container time/logs with the host. |
+
+On first start, if `/etc/ocserv/ocserv.conf` is missing, the container copies a default template into place (see [Architecture and Internals#init-config](Architecture-and-Internals#init-config)).
+
+## Ports
+
+| Port | Protocol | Purpose |
+|---|---|---|
+| `443` | TCP | Primary VPN transport (TLS). Also what camouflage presents as HTTPS. |
+| `443` | UDP | DTLS transport (faster). Optional — only used if `udp-port` is set in `ocserv.conf`. |
+
+Map them to whatever host port you like, e.g. `8443:443/tcp`. If you run behind another service already on `443` (like SWAG), publish ocserv on a different host port such as `8443`.
+
+> **DTLS in Docker:** UDP/DTLS can misbehave behind Docker's userland proxy (reconnect loops). Many deployments run **TCP-only** (omit `udp-port` and the UDP port mapping). It's also stealthier for camouflage. See [Troubleshooting#dtls--udp-reconnect-loops](Troubleshooting#dtls--udp-reconnect-loops).
+
+## Capabilities, devices, sysctls
+
+| Requirement | Why |
+|---|---|
+| `--cap-add=NET_ADMIN` | Configure interfaces, routes, and nftables rules. |
+| `--device /dev/net/tun:/dev/net/tun` | Create the TUN tunnel device. |
+| `--sysctl net.ipv4.ip_forward=1` | Forward client traffic to the internet. |
+| `--sysctl net.ipv6.conf.all.forwarding=1` | Only needed if you actually route IPv6. |
+
+> `--privileged` would also work but is **not recommended** — the three settings above are the least-privilege way to grant exactly what ocserv needs.
+
+---
+
+Next: **[[ocserv Configuration]]** · **[[Networking NAT and Routing]]**

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -1,0 +1,40 @@
+# FAQ
+
+**What protocol does this use? Which clients work?**
+The OpenConnect / Cisco AnyConnect SSL-VPN protocol. Works with the `openconnect` client, Cisco AnyConnect / Secure Client, mobile OpenConnect apps, and routers like Keenetic / Netcraze. See [[Clients and Devices]].
+
+**Which image tag should I use?**
+`ghcr.io/azinchen/ocserv-server:dev` for the latest development build (the `main` branch), or `azinchen/ocserv-server:latest` / a pinned `:x.y.z` for releases. See [[Building and CI]].
+
+**Do I have to run it privileged?**
+No. It needs `--cap-add=NET_ADMIN`, the `/dev/net/tun` device, and `net.ipv4.ip_forward=1`. `--privileged` works but is discouraged. See [Configuration Reference#capabilities-devices-sysctls](Configuration-Reference#capabilities-devices-sysctls).
+
+**Does it use iptables?**
+No — it's built with ocserv's nftables backend and ships `nft`. Container NAT is set up as an nftables `inet` table. See [[Networking NAT and Routing]].
+
+**Does it support `PUID`/`PGID`?**
+No. Those LinuxServer-style variables are ignored. ocserv drops privileges via `run-as-user`/`run-as-group` in the config.
+
+**Why does `occtl show status` show 0 bytes RX/TX for a connected user?**
+Those counters update on disconnect. For live traffic, read the tunnel interface counters. See [Troubleshooting#how-do-i-prove-the-tunnel-actually-works](Troubleshooting#how-do-i-prove-the-tunnel-actually-works).
+
+**Can SWAG reverse-proxy the VPN?**
+No — the VPN protocol isn't a proxyable HTTP stream. SWAG only provides the TLS certificate; ocserv is exposed directly on its own port. See [[Reverse Proxy and Certificates]].
+
+**Should I enable DTLS (UDP)?**
+It's faster, but UDP/DTLS behind Docker's userland proxy can cause reconnect loops, and UDP traffic weakens camouflage. Many run TCP-only. See [Configuration Reference#ports](Configuration-Reference#ports).
+
+**Why is IPv6 disabled in the samples?**
+Because advertising IPv6 without real IPv6 egress blackholes client IPv6 traffic. It's opt-in and requires Docker IPv6 + `IPV6_NAT=1`. See [Networking NAT and Routing#ipv6](Networking-NAT-and-Routing#ipv6).
+
+**How do I rotate the camouflage secret?**
+Change `camouflage_secret` in `ocserv.conf` and restart. Update client URLs to the new `/?secret`. See [[Camouflage Mode]].
+
+**How do I add a user?**
+`docker exec -it ocserv-server ocpasswd -c /etc/ocserv/ocpasswd alice`. See [[User Management]].
+
+**Do config changes need a restart?**
+Yes for `ocserv.conf` and certificates. New/changed `ocpasswd` users take effect on the next login without a restart.
+
+**Where's the upstream documentation?**
+ocserv project: https://ocserv.gitlab.io/www/ · this image: https://github.com/azinchen/ocserv-server

--- a/wiki/Gateway-Mode.md
+++ b/wiki/Gateway-Mode.md
@@ -1,0 +1,129 @@
+# Gateway Mode — route clients through another VPN
+
+Gateway mode sends your VPN clients' traffic **out through an upstream VPN container** instead of straight out the host. Typical use: chain ocserv in front of a commercial VPN (e.g. [NordVPN](https://github.com/azinchen/nordvpn)) so clients connect to your own OpenConnect server but exit with the commercial VPN's IP.
+
+```
+client ──openconnect──▶ ocserv ──policy route──▶ nordvpn ──tun0──▶ internet
+ 10.20.0.x             SNAT→172.28.0.3          (FORWARD_FROM)   commercial exit IP
+```
+
+ocserv keeps its own network namespace and its inbound listener works normally; only the **client subnet** is steered to the upstream gateway.
+
+## Enabling it
+
+Set `VPN_GATEWAY` to the upstream container's IP on the shared Docker network:
+
+| Variable | Default | Description |
+|---|---|---|
+| `VPN_GATEWAY` | _(unset)_ | Upstream gateway IP. Steers `VPN_SUBNET` to it and installs the kill switch. Unset = normal standalone ocserv. |
+| `VPN_GATEWAY6` | _(unset)_ | Upstream IPv6 gateway. Set it to route the IPv6 client subnet too; unset = forwarded client IPv6 is dropped. |
+| `VPN_GATEWAY_TABLE` | `100` | Routing table used for the gateway default route. |
+| `VPN_GATEWAY_RULE_PRIO` | `1000` | Priority of the `from <VPN_SUBNET>` policy rule. |
+
+When `VPN_GATEWAY` is unset, the `init-vpngw` service is a no-op — ocserv behaves exactly as a standalone server (including normal IPv6).
+
+## How it works
+
+1. **Source-based policy routing** — `init-vpngw` adds `ip rule from <VPN_SUBNET> lookup <table>` and a default route in that table via `VPN_GATEWAY`. Only client-sourced packets follow it; ocserv's own traffic and the inbound listener keep the main default route.
+2. **Masquerade** — `init-nat` already SNATs clients to the container's own address, so the upstream sees a Docker-subnet source and needs **no return route** to your client subnet.
+3. **Kill switch** — a dedicated nft table (`inet ocserv_gw`) drops any client packet that would egress the WAN by a next-hop other than the gateway. See below.
+
+### Why not just set a default gateway?
+
+Pointing ocserv's **default route** at the upstream breaks inbound: a reply to a connecting client would follow the default route into the upstream tunnel and exit with the wrong source IP, so the client drops it. Source-based policy routing avoids this — the listener's replies stay on the main route, only client traffic is redirected.
+
+## Kill switch (fail-closed)
+
+The policy route already forces client traffic to the gateway, but the kill switch makes leaks impossible if that route is ever missing:
+
+```nft
+table inet ocserv_gw {
+    chain forward {
+        type filter hook forward priority -10; policy accept;
+        ip  saddr 10.20.0.0/24 oifname "eth0" rt ip  nexthop != 172.28.0.2 drop
+        ip6 saddr fd20:…::/64  oifname "eth0" rt ip6 nexthop != fd00::2    drop   # if VPN_GATEWAY6 set
+        # meta nfproto ipv6 iifname "vpns*" drop   # if VPN_GATEWAY6 unset
+    }
+}
+```
+
+What happens when the upstream is unavailable:
+
+| Situation | Result |
+|---|---|
+| Upstream tunnel **down** (container up) | Forwarded client packets have no `tun0` to exit on the upstream; the upstream's `FORWARD` policy `DROP` blocks them. **No leak.** |
+| Upstream container **stopped/absent** | The gateway IP doesn't answer ARP; the policy-routed packets are dropped at ocserv. **No leak.** |
+| Policy route somehow **missing** | The next-hop guard above drops client traffic instead of letting it fall through to the host. **No leak.** |
+
+In every case clients lose internet rather than leaking out the host's real IP.
+
+## IPv6
+
+- **Upstream is IPv4-only** (the NordVPN container is, by default): leave `VPN_GATEWAY6` unset. Forwarded client IPv6 is dropped so it can't bypass the IPv4 policy rule.
+- **Upstream is dual-stack**: set `VPN_GATEWAY6` to its IPv6 address. ocserv policy-routes `IPV6_SUBNET` to it with the same fail-closed next-hop guard. This also needs working IPv6 on the Docker network and the upstream forwarding IPv6 (see [Networking NAT and Routing#ipv6](Networking-NAT-and-Routing#ipv6)).
+
+## Upstream requirements (NordVPN example)
+
+The upstream must forward the Docker subnet out its tunnel. The companion [NordVPN image](https://github.com/azinchen/nordvpn) does this with `FORWARD_FROM`:
+
+```yaml
+networks:
+  vpnnet:
+    ipam:
+      config:
+        - subnet: 172.28.0.0/24
+
+services:
+  nordvpn:
+    image: azinchen/nordvpn:latest
+    cap_add: [NET_ADMIN]
+    devices: [/dev/net/tun]
+    sysctls:
+      - net.ipv4.ip_forward=1
+    environment:
+      - USER=service_username
+      - PASS=service_password
+      - COUNTRY=Netherlands
+      - FORWARD_FROM=172.28.0.0/24      # let the Docker net route out the tunnel
+    networks:
+      vpnnet:
+        ipv4_address: 172.28.0.2
+
+  ocserv:
+    image: azinchen/ocserv-server:latest
+    cap_add: [NET_ADMIN]
+    devices: [/dev/net/tun]
+    sysctls:
+      - net.ipv4.ip_forward=1
+    environment:
+      - VPN_SUBNET=10.20.0.0/24
+      - VPN_GATEWAY=172.28.0.2          # the nordvpn container
+    ports:
+      - "443:443/tcp"                   # published normally on ocserv itself
+      - "443:443/udp"
+    volumes:
+      - ./config:/etc/ocserv
+    networks:
+      vpnnet:
+        ipv4_address: 172.28.0.3
+```
+
+`FORWARD_FROM` must list the subnet ocserv SNATs into (the Docker network, `172.28.0.0/24`), not the client subnet.
+
+## Verify
+
+```bash
+# policy routing on ocserv
+docker exec ocserv-server ip rule
+docker exec ocserv-server ip route show table 100
+
+# kill switch
+docker exec ocserv-server nft list table inet ocserv_gw
+
+# a connected client's exit IP should equal the upstream's, not the host's
+docker exec ocserv-server sh -c 'curl -s https://1.1.1.1/cdn-cgi/trace | grep ^ip='
+```
+
+---
+
+Next: **[[Networking NAT and Routing]]** · **[[Troubleshooting]]**

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,0 +1,97 @@
+# Getting Started
+
+This walks you from nothing to a working VPN connection.
+
+## Prerequisites
+
+- A Linux host with Docker (and ideally Docker Compose)
+- The `/dev/net/tun` device available on the host (standard on virtually all Linux)
+- A TCP (and optionally UDP) port reachable from your clients — `443` by default
+- A TLS certificate for your server (self-signed for testing, or Let's Encrypt for production — see [[Reverse Proxy and Certificates]])
+
+## 1. Create the layout
+
+```bash
+mkdir -p ocserv-server/volumes/config
+cd ocserv-server
+```
+
+## 2. Provide a configuration
+
+The container ships a default `ocserv.conf` template that it copies in on first start if none exists, but you almost always want to start from one of the documented configuration variants:
+
+| Variant | Use it for |
+|---|---|
+| [Basic Standalone](ocserv-Configuration-Basic) | Standalone server, you supply certs |
+| [Self-Signed](ocserv-Configuration-Self-Signed) | Local testing with a self-signed cert |
+| [SWAG Integration](ocserv-Configuration-SWAG-Integration) | Production behind SWAG / Let's Encrypt |
+
+Copy one to `volumes/config/ocserv.conf` and edit it (domain, subnet, cert paths). See [[ocserv Configuration]] for what the directives mean.
+
+## 3. Write a compose file
+
+```yaml
+services:
+  ocserv:
+    image: azinchen/ocserv-server:latest
+    container_name: ocserv-server
+    restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    sysctls:
+      - net.ipv4.ip_forward=1
+      - net.ipv6.conf.all.forwarding=1
+    ports:
+      - 443:443/tcp
+      - 443:443/udp
+    environment:
+      - VPN_SUBNET=10.20.0.0/24
+    volumes:
+      - ./volumes/config:/etc/ocserv
+```
+
+Every knob here is explained in [[Configuration Reference]].
+
+## 4. Start it
+
+```bash
+docker compose up -d
+docker compose logs -f
+```
+
+A healthy startup looks like:
+
+```
+[INIT-CONFIG] ocserv configuration file is present
+[INIT-NAT] Setting up IPv4 NAT for subnet 10.20.0.0/24 via eth0
+[INIT-NAT] NAT and forwarding setup complete
+[SVC-OCSERV] Starting ocserv service
+listening (TCP) on 0.0.0.0:443...
+sec-mod: sec-mod initialized
+```
+
+## 5. Create a user
+
+```bash
+docker exec -it ocserv-server ocpasswd -c /etc/ocserv/ocpasswd alice
+```
+
+It prompts for a password. More in [[User Management]].
+
+## 6. Connect
+
+```bash
+sudo openconnect https://vpn.example.com --user=alice
+```
+
+If you used a self-signed cert, pin it instead of disabling verification — see [[Clients and Devices]]. If you enabled camouflage, the URL must include the secret — see [[Camouflage Mode]].
+
+## 7. Verify it actually carries traffic
+
+Connecting only proves authentication. To confirm the data plane works, see the verification steps in [Troubleshooting](Troubleshooting#how-do-i-prove-the-tunnel-actually-works).
+
+---
+
+Next: **[[Configuration Reference]]** · **[[ocserv Configuration]]**

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,59 @@
+# ocserv-server Wiki
+
+**OpenConnect VPN Server (ocserv) in a Docker container, supervised by s6-overlay.**
+
+`ocserv-server` packages [ocserv](https://ocserv.gitlab.io/www/) — the OpenConnect VPN server — into a small, self-configuring Alpine-based container image. It builds ocserv from source, wires up NAT/forwarding automatically with **nftables**, and supervises the daemon with **s6-overlay** so the container behaves like a proper init system.
+
+It speaks the OpenConnect/Cisco AnyConnect SSL-VPN protocol, so it works with the `openconnect` client, the Cisco AnyConnect client, mobile clients, and routers such as Keenetic / Netcraze.
+
+---
+
+## What you get
+
+- **ocserv** built from source on **Alpine Linux** (Meson build, nftables firewall backend)
+- **Automatic NAT & forwarding** — the container sets up masquerading for your VPN subnet on startup
+- **s6-overlay** supervision — clean startup ordering, logging, and restarts
+- **Camouflage mode** — hide the VPN behind what looks like an ordinary HTTPS website to defeat DPI / censorship
+- **Gateway mode** — chain clients out through an upstream VPN (e.g. NordVPN) with a fail-closed kill switch
+- **Reverse-proxy friendly** — designed to share Let's Encrypt certificates with [SWAG](https://github.com/linuxserver/docker-swag)
+- **Multi-arch images** published to GHCR (and Docker Hub for releases)
+
+---
+
+## Start here
+
+| If you want to… | Go to |
+|---|---|
+| Get a server running in 5 minutes | **[[Getting Started]]** |
+| Understand every env var, volume, and port | **[[Configuration Reference]]** |
+| Tune the `ocserv.conf` itself | **[[ocserv Configuration]]** |
+| Add / remove VPN users | **[[User Management]]** |
+| Hide the VPN from DPI | **[[Camouflage Mode]]** |
+| Use Let's Encrypt certs via SWAG | **[[Reverse Proxy and Certificates]]** |
+| Understand NAT, routing, full vs split tunnel | **[[Networking NAT and Routing]]** |
+| Route clients out through another VPN (e.g. NordVPN) | **[[Gateway Mode]]** |
+| Connect a client or router | **[[Clients and Devices]]** |
+| See how the image is built internally | **[[Architecture and Internals]]** |
+| Fix a problem | **[[Troubleshooting]]** |
+| Build it yourself / understand image tags | **[[Building and CI]]** |
+| Quick answers | **[[FAQ]]** |
+
+---
+
+## At a glance
+
+```bash
+docker run -d --name ocserv-server \
+  --cap-add=NET_ADMIN \
+  --device /dev/net/tun:/dev/net/tun \
+  --sysctl net.ipv4.ip_forward=1 \
+  -p 443:443/tcp -p 443:443/udp \
+  -e VPN_SUBNET=10.20.0.0/24 \
+  -v ./config:/etc/ocserv \
+  azinchen/ocserv-server:latest
+```
+
+Then create a user and connect — see **[[Getting Started]]**.
+
+> **Project:** https://github.com/azinchen/ocserv-server
+> **License:** MIT

--- a/wiki/Networking-NAT-and-Routing.md
+++ b/wiki/Networking-NAT-and-Routing.md
@@ -1,0 +1,102 @@
+# Networking, NAT and Routing
+
+How client traffic reaches the internet, how the container sets up NAT, and how to choose full vs split tunnel.
+
+## The path a packet takes
+
+```
+VPN client ─► (encrypted) ─► ocserv ─► vpns0 (10.20.0.x) ─► [forward + masquerade] ─► eth0 ─► internet
+```
+
+1. The client connects over TLS (or DTLS) to port 443.
+2. ocserv decrypts and writes the inner packet to a TUN device (`vpns0`, …).
+3. The kernel **forwards** it toward the WAN interface (requires `ip_forward=1`).
+4. nftables **masquerades** the source address to the container's WAN IP so replies can come back.
+5. Replies are reversed back through the tunnel to the client.
+
+## Automatic NAT setup (nftables)
+
+On startup the `init-nat` service enables forwarding and installs a dedicated nftables table. It's idempotent (rebuilt on each start) and uses the modern `inet` family so one rule set covers IPv4 (and IPv6 when enabled):
+
+```nft
+table inet ocserv {
+    chain forward {
+        type filter hook forward priority 0; policy accept;
+        iifname "vpns*" oifname "eth0" accept
+        iifname "eth0" oifname "vpns*" ct state established,related accept
+    }
+    chain postrouting {
+        type nat hook postrouting priority 100; policy accept;
+        ip saddr 10.20.0.0/24 oifname "eth0" masquerade
+    }
+}
+```
+
+- The masqueraded subnet comes from **`VPN_SUBNET`**.
+- The egress interface comes from **`WAN_IF`**.
+- The tunnel interface pattern comes from **`VPN_IF`** (`vpns+` → `vpns*`).
+
+Inspect it live:
+
+```bash
+docker exec ocserv-server nft list table inet ocserv
+```
+
+> The image is built with ocserv's **nftables** firewall backend and ships `nft` (not `iptables`). `--cap-add=NET_ADMIN` is required to install these rules.
+
+## Keep three things in sync
+
+For NAT to work, these must agree:
+
+| Container (`VPN_SUBNET`) | `ocserv.conf` (`ipv4-network`/`ipv4-netmask`) |
+|---|---|
+| `10.20.0.0/24` | `10.20.0.0` / `255.255.255.0` |
+
+If they don't match, clients get addresses that nftables never masquerades, and their traffic silently fails to reach the internet.
+
+## Full vs split tunnel
+
+Controlled in `ocserv.conf`:
+
+```ini
+# Full tunnel — ALL client traffic goes through the VPN
+route = default
+
+# Split tunnel — only these networks go through the VPN; the rest uses the
+# client's normal connection
+# route = 10.0.0.0/8
+# route = 192.168.1.0/24
+```
+
+- **Full tunnel** is what you want for privacy / censorship circumvention. Pair it with `tunnel-all-dns = true` so DNS can't leak outside the tunnel.
+- **Split tunnel** is for reaching specific internal networks while leaving general browsing on the local link.
+
+> **Routers (e.g. Keenetic / Netcraze) and full tunnel:** even when the server pushes `route = default`, a router won't necessarily send its own/its LAN's traffic through the tunnel — that's a router-side **policy-based routing** decision you configure on the router. See [Clients and Devices](Clients-and-Devices#keenetic-and-netcraze-routers).
+
+## IPv6
+
+IPv6 is **off by default** in the maintained samples, on purpose.
+
+The failure mode: if you advertise an IPv6 address + `route = ::/0` to clients but the container can't actually route IPv6 to the internet (no IPv6 on the Docker bridge, `IPV6_NAT=0`), client IPv6 traffic is **blackholed** — it goes into the tunnel and dies, with connections hanging before falling back to IPv4.
+
+To enable IPv6 **correctly**:
+
+1. Give the container's Docker network working IPv6 (enable IPv6 in the Docker daemon / network).
+2. Set `IPV6_NAT=1` (and keep `IPV6_FORWARD=1`).
+3. In `ocserv.conf`, add `ipv6-network`, `route = ::/0`, and IPv6 `dns` servers.
+
+Verify the container truly has IPv6 egress before advertising it:
+
+```bash
+docker exec ocserv-server ping -6 -c2 2606:4700:4700::1111
+```
+
+If that fails, leave IPv6 off.
+
+## Routing clients through another VPN
+
+To send client traffic out through an upstream VPN container (e.g. NordVPN) instead of straight out the WAN, set `VPN_GATEWAY`. ocserv then policy-routes the client subnet to that gateway and adds a fail-closed kill switch. See **[[Gateway Mode]]**.
+
+---
+
+Next: **[[Gateway Mode]]** · **[[Clients and Devices]]** · **[[Troubleshooting]]**

--- a/wiki/Reverse-Proxy-and-Certificates.md
+++ b/wiki/Reverse-Proxy-and-Certificates.md
@@ -1,0 +1,89 @@
+# Reverse Proxy and Certificates
+
+ocserv needs a TLS certificate. For production you want a real, browser-trusted certificate (Let's Encrypt), and you often already run a reverse proxy that manages those certs. This image is designed to integrate cleanly with [**SWAG**](https://github.com/linuxserver/docker-swag) (Secure Web Application Gateway), which automates Let's Encrypt issuance/renewal.
+
+## The integration model
+
+A key point: **SWAG does not proxy the VPN traffic.** The OpenConnect protocol isn't a plain HTTP stream you can reverse-proxy, so ocserv is exposed **directly** on its own host port (e.g. `8443`). SWAG's only role is to **issue and renew the certificates**, which ocserv reads from a shared, read-only mount.
+
+```
+            ┌─────────────────────────────┐
+Client ───► │ host:8443 ──► ocserv (TLS)   │   ← VPN traffic, direct
+            └─────────────────────────────┘
+                       ▲ reads certs (ro)
+            ┌──────────┴──────────────────┐
+            │ SWAG  (issues/renews LE)     │   ← never sees VPN traffic
+            └─────────────────────────────┘
+```
+
+## Wiring it up
+
+Mount SWAG's config directory into ocserv read-only and point the cert directives at it:
+
+```yaml
+services:
+  ocserv:
+    image: azinchen/ocserv-server:latest
+    # ...
+    ports:
+      - 8443:443/tcp        # direct, separate from SWAG's 443
+    volumes:
+      - ./volumes/config:/etc/ocserv
+      - ../reverse-proxy/volumes/swag-config:/swag-config:ro
+```
+
+In `ocserv.conf`:
+
+```ini
+server-cert = /swag-config/etc/letsencrypt/live/example.com/fullchain.pem
+server-key  = /swag-config/etc/letsencrypt/live/example.com/privkey.pem
+```
+
+### Wildcard certificates
+
+A SWAG **wildcard** cert (`SUBDOMAINS=wildcard`, DNS validation) for `*.example.com` covers any VPN hostname like `gate.example.com`. The Let's Encrypt `live/` directory is named after SWAG's main `URL` (e.g. `example.com`), so the path is `…/live/example.com/`. Confirm the SAN covers your VPN host:
+
+```bash
+openssl x509 -in .../live/example.com/fullchain.pem -noout -ext subjectAltName
+```
+
+### Do they need to share a Docker network?
+
+No. Because SWAG doesn't proxy the VPN, ocserv does **not** need to be on SWAG's Docker network — it only needs the cert files. Running ocserv on its own default bridge is perfectly fine.
+
+## Certificate renewal → restart ocserv
+
+ocserv loads certificates **at startup**. When SWAG renews the Let's Encrypt cert, ocserv keeps using the old one in memory until it restarts. Add a SWAG post-renewal hook to restart ocserv automatically.
+
+Create `…/swag-config/etc/letsencrypt/renewal-hooks/post/restart-ocserv.sh`:
+
+```bash
+#!/bin/bash
+docker restart ocserv-server
+```
+
+Make it executable:
+
+```bash
+chmod +x .../renewal-hooks/post/restart-ocserv.sh
+```
+
+This runs after each successful renewal. Active sessions drop briefly while ocserv restarts, then clients reconnect.
+
+> The restart needs access to the Docker socket from inside SWAG, or run the hook on the host. Adapt to your setup.
+
+## Self-signed certificates (testing only)
+
+For local testing without a domain, use a self-signed cert and have clients pin it rather than disabling verification. See [Self-Signed](ocserv-Configuration-Self-Signed) for full generation steps. Pinning example:
+
+```bash
+FPRINT=$(openssl x509 -noout -fingerprint -sha256 \
+  -in volumes/config/server-cert.pem | cut -d= -f2 | tr -d ':')
+sudo openconnect --servercert "sha256:$FPRINT" https://SERVER_IP --user=alice
+```
+
+> Self-signed certs undermine [camouflage](Camouflage-Mode) — use a trusted cert in production.
+
+---
+
+Next: **[[Networking NAT and Routing]]** · **[[Clients and Devices]]**

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,0 +1,96 @@
+# Troubleshooting
+
+## First moves
+
+```bash
+docker logs ocserv-server                         # startup + ocserv messages
+docker exec ocserv-server occtl show status       # is ocserv online?
+docker exec ocserv-server occtl show users        # who's connected
+docker exec ocserv-server nft list table inet ocserv   # NAT rules present?
+```
+
+---
+
+## ocserv won't start
+
+### `error loading the certificate or key file`
+The `server-cert` / `server-key` paths in `ocserv.conf` don't exist inside the container. Check the paths and that the volume (or `/swag-config`) is mounted. Validate first:
+
+```bash
+docker run --rm -v ./volumes/config:/etc/ocserv:ro \
+  --entrypoint /usr/sbin/ocserv azinchen/ocserv-server:latest \
+  -t -c /etc/ocserv/ocserv.conf
+```
+
+### `error: cannot open file ../tests/certs/...`
+You're using an unedited upstream sample config that points at ocserv's test certs. Use this image's maintained samples (which point at `/etc/ocserv/...`) and set your real cert paths.
+
+### Config errors on `--test-config`
+Anything that isn't a `note:` line is a real error — fix the directive it names before restarting.
+
+---
+
+## Clients can't connect at all
+
+- **Port not reachable:** confirm the host publishes the port and the firewall/router forwards it. `ss -lntp | grep <port>` on the host should show docker-proxy listening.
+- **Camouflage secret missing:** if `camouflage = true`, a client URL without `/?your-secret` gets a `401`/`404`, not a VPN. See [[Camouflage Mode]].
+- **Certificate untrusted:** with a self-signed cert, pin it (`--servercert sha256:...`) rather than ignoring verification. See [[Clients and Devices]].
+
+---
+
+## Connected, but no internet (data plane dead)
+
+Authentication succeeded but traffic doesn't flow. Check, in order:
+
+1. **NAT rules present?** `docker exec ocserv-server nft list table inet ocserv` should show a `masquerade` rule for your subnet.
+2. **Subnet mismatch?** `VPN_SUBNET` (container) **must** equal `ipv4-network`/`ipv4-netmask` (`ocserv.conf`). A mismatch means client IPs are never masqueraded. See [Networking NAT and Routing#keep-three-things-in-sync](Networking-NAT-and-Routing#keep-three-things-in-sync).
+3. **Forwarding on?** The host needs `--sysctl net.ipv4.ip_forward=1`. The `init-nat` log will warn if it couldn't enable it.
+4. **Container egress works?** `docker exec ocserv-server ping -c2 1.1.1.1`. If this fails, it's a host/Docker networking problem, not ocserv.
+5. **Router not routing through the tunnel?** For Keenetic / Netcraze and similar, the tunnel can be up while the router still uses its ISP. Configure policy-based routing on the router. See [Clients and Devices](Clients-and-Devices#keenetic-and-netcraze-routers).
+
+---
+
+## IPv6 sites hang / slow to load
+
+Classic IPv6 **blackhole**: clients were handed an IPv6 address + `::/0` route, but the server has no IPv6 egress. Either disable IPv6 in `ocserv.conf` (remove `ipv6-network`, `route = ::/0`, IPv6 `dns`) or enable it properly (`IPV6_NAT=1` + Docker IPv6). See [Networking NAT and Routing#ipv6](Networking-NAT-and-Routing#ipv6).
+
+---
+
+## DTLS / UDP reconnect loops
+
+Symptom: the client connects, then repeatedly drops/reconnects, often when DTLS (UDP) is enabled behind Docker's userland proxy. Fixes:
+
+- **Go TCP-only:** remove `udp-port` from `ocserv.conf` and drop the UDP port mapping. Simplest and stealthier for camouflage.
+- Or disable Docker's userland proxy / use host networking if you need DTLS performance.
+
+---
+
+## DNS leaks on full tunnel
+
+Add `tunnel-all-dns = true` and push `dns` servers in `ocserv.conf` so clients can't bypass the tunnel's DNS. See [ocserv Configuration#dns](ocserv-Configuration#dns).
+
+---
+
+## How do I prove the tunnel actually works?
+
+`occtl` per-session RX/TX only update on disconnect, so use the **tunnel interface counters**. Snapshot them, generate a few pings from the client (e.g. ping `10.20.0.1`), then re-check:
+
+```bash
+docker exec ocserv-server sh -c \
+  'for s in rx_packets tx_packets rx_bytes tx_bytes; do \
+     printf "%-12s %s\n" $s $(cat /sys/class/net/vpns0/statistics/$s); done'
+```
+
+If `rx_packets` climbs by the number of pings you sent, the data path is confirmed. Pinging the gateway `10.20.0.1` proves the tunnel; pinging `1.1.1.1` proves routing + NAT end-to-end.
+
+> Server→client pings often get no reply because many clients (routers especially) firewall ICMP to their own tunnel IP — that alone is **not** a sign of breakage. Trust the counters and client→server/client→internet tests.
+
+---
+
+## Changes to ocserv.conf don't apply
+
+ocserv reads config (and certificates) at startup. **Restart** the container after editing: `docker restart ocserv-server`.
+
+---
+
+Next: **[[FAQ]]**

--- a/wiki/User-Management.md
+++ b/wiki/User-Management.md
@@ -1,0 +1,82 @@
+# User Management
+
+With the default `auth = "plain[passwd=/etc/ocserv/ocpasswd]"`, users live in the `ocpasswd` file. You manage them with the `ocpasswd` tool inside the container, and monitor live sessions with `occtl`.
+
+## The ocpasswd file
+
+- Location: `/etc/ocserv/ocpasswd` (inside your mounted config volume — persisted).
+- Format: one user per line, `username:realm:hash`. Passwords are stored hashed; never plaintext.
+- Changes are picked up for **new** logins immediately — no restart needed.
+
+## Add or update a user
+
+```bash
+docker exec -it ocserv-server ocpasswd -c /etc/ocserv/ocpasswd alice
+```
+
+`-c` points at the password file. You'll be prompted for the password twice. Running it again for an existing user updates the password.
+
+## Delete a user
+
+```bash
+docker exec -it ocserv-server ocpasswd -c /etc/ocserv/ocpasswd -d alice
+```
+
+## List users
+
+```bash
+docker exec ocserv-server cat /etc/ocserv/ocpasswd
+```
+
+(Shows usernames and hashes — not plaintext passwords.)
+
+## Scripting user creation
+
+For automation (no interactive prompt), feed the password twice on stdin:
+
+```bash
+printf 'S3cret\nS3cret\n' | \
+  docker exec -i ocserv-server ocpasswd -c /etc/ocserv/ocpasswd alice
+```
+
+## Monitoring with occtl
+
+`occtl` is ocserv's control/monitoring tool (enabled by `use-occtl = true`).
+
+```bash
+# Who's connected right now (user, real IP, assigned VPN IP, device, uptime)
+docker exec ocserv-server occtl show users
+
+# Server status, session counts, auth failures, ban list
+docker exec ocserv-server occtl show status
+
+# Details for one user
+docker exec ocserv-server occtl show user alice
+
+# Disconnect a user
+docker exec ocserv-server occtl disconnect user alice
+```
+
+Example `show users` output:
+
+```
+   id   user    vhost      ip            vpn-ip      device  since   dtls-cipher  status
+  106   alice  default  203.0.113.5   10.20.0.190   vpns0   1h:09m  (no-dtls)    connected
+```
+
+> **Note:** the per-session RX/TX byte counters in `occtl show status` are only updated when a user **disconnects**, so they read `0` for active sessions. To watch live traffic, read the tunnel interface counters instead — see [Troubleshooting#how-do-i-prove-the-tunnel-actually-works](Troubleshooting#how-do-i-prove-the-tunnel-actually-works).
+
+## Other auth backends
+
+The `ocpasswd` flow above is the default and simplest. ocserv also supports:
+
+- **PAM** — `auth = "pam"`
+- **RADIUS** — `auth = "radius[config=/etc/radcli/radiusclient.conf]"`
+- **Certificate** — client-certificate authentication
+- **GSSAPI / Kerberos**
+
+These require additional configuration and possibly mounting extra files; consult the upstream ocserv manual.
+
+---
+
+Next: **[[Camouflage Mode]]** · **[[Clients and Devices]]**

--- a/wiki/_Footer.md
+++ b/wiki/_Footer.md
@@ -1,0 +1,1 @@
+[ocserv-server](https://github.com/azinchen/ocserv-server) · MIT License · Built on [ocserv](https://ocserv.gitlab.io/www/) + [s6-overlay](https://github.com/just-containers/s6-overlay)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,27 @@
+### ocserv-server
+
+**[[Home]]**
+
+**Setup**
+- [[Getting Started]]
+- [[Configuration Reference]]
+- [[ocserv Configuration]]
+- [Basic Standalone](ocserv-Configuration-Basic)
+- [Self-Signed](ocserv-Configuration-Self-Signed)
+- [SWAG Integration](ocserv-Configuration-SWAG-Integration)
+
+**Operating**
+- [[User Management]]
+- [[Camouflage Mode]]
+- [[Reverse Proxy and Certificates]]
+- [[Networking NAT and Routing]]
+- [[Gateway Mode]]
+- [[Clients and Devices]]
+
+**Under the hood**
+- [[Architecture and Internals]]
+- [[Building and CI]]
+
+**Help**
+- [[Troubleshooting]]
+- [[FAQ]]

--- a/wiki/ocserv-Configuration-Basic.md
+++ b/wiki/ocserv-Configuration-Basic.md
@@ -1,0 +1,151 @@
+# ocserv Configuration: Basic Standalone
+
+A single ocserv container that terminates TLS itself on a public port, with **no reverse proxy in front**. You bring your own certificate — Let's Encrypt via certbot, a commercial cert, or your own CA — and place it next to the config. This is the most direct way to run the server, and the right choice when ocserv is the only thing using port 443 on the host.
+
+The directives are explained line-by-line in [[ocserv Configuration]]; this page gives you a complete, working file plus the compose and connection details for this scenario.
+
+## When to use this
+
+- ocserv is the only service on the host's port 443 (nothing else to share it with)
+- You already obtain and renew certificates some other way (certbot, your CA, etc.)
+- You want the simplest possible topology — one container, one port, no proxy
+
+If another service already owns 443, or you want SWAG to manage Let's Encrypt for you, use [SWAG Integration](ocserv-Configuration-SWAG-Integration) instead. For a lab with no public domain, use [Self-Signed](ocserv-Configuration-Self-Signed).
+
+## How the pieces fit
+
+Everything ocserv needs lives in one mounted directory (`/etc/ocserv`): the config, the user database, and your certificate/key. The container publishes its TLS port to the host, and the built-in startup scripts handle NAT/forwarding automatically (see [[Architecture and Internals]]). You supply three things — a certificate, a config, and at least one user.
+
+```
+ocserv-server/
+├── docker-compose.yml
+└── volumes/
+    └── config/
+        ├── ocserv.conf        # the config below
+        ├── ocpasswd           # user database (see User Management)
+        ├── fullchain.pem      # your server certificate
+        └── privkey.pem        # your private key
+```
+
+## The configuration
+
+Copy this to `volumes/config/ocserv.conf`. At minimum, change `camouflage_secret`; adjust the subnet and DNS if you like. Keep `ipv4-network` in sync with `VPN_SUBNET` in the compose file — if they disagree, client traffic won't be NAT'd and the internet won't work (see [Networking, NAT and Routing](Networking-NAT-and-Routing#keep-three-things-in-sync)).
+
+```ini
+# --- Ports (container-internal; the host maps to these) ---
+tcp-port = 443
+# DTLS/UDP is off by default — TCP-only is stealthier for camouflage and avoids
+# the Docker userland-proxy DTLS reconnect loop. To enable DTLS: uncomment the
+# next line AND publish 443/udp in compose. See Configuration Reference.
+#udp-port = 443
+
+# --- Certificates (you supply these) ---
+server-cert = /etc/ocserv/fullchain.pem
+server-key  = /etc/ocserv/privkey.pem
+
+# --- Camouflage (hide as a normal HTTPS site) — CHANGE THE SECRET ---
+camouflage = true
+camouflage_secret = "change-me-to-a-long-random-secret"
+camouflage_realm = "Restricted Content"
+compression = false
+cookie-timeout = 300
+
+# --- Auth (local password file) ---
+auth = "plain[passwd=/etc/ocserv/ocpasswd]"
+
+# --- Addressing (must match VPN_SUBNET in compose) ---
+device = vpns
+ipv4-network = 10.10.0.0
+ipv4-netmask = 255.255.255.0
+
+# --- Full-tunnel route ---
+route = default
+
+# --- DNS (forced through the tunnel to prevent leaks) ---
+tunnel-all-dns = true
+dns = 1.1.1.1
+dns = 9.9.9.9
+
+# --- Transport / sessions ---
+try-mtu-discovery = true
+dpd = 90
+mobile-dpd = 180
+keepalive = 300
+isolate-workers = true
+max-clients = 16
+max-same-clients = 2
+auth-timeout = 240
+idle-timeout = 0
+
+# --- Runtime + control socket ---
+pid-file    = /run/ocserv/ocserv.pid
+socket-file = /run/ocserv/ocserv.socket
+use-occtl = true
+occtl-socket-file = /var/run/occtl.socket
+
+# --- Privilege separation ---
+run-as-user = nobody
+run-as-group = daemon
+
+# --- Security & compatibility ---
+cisco-client-compat = true
+predictable-ips = true
+deny-roaming = false
+banner = "Welcome to OpenConnect VPN Server"
+```
+
+> IPv6 is intentionally omitted. Advertising an IPv6 address and a `::/0` route to clients while the container has no working IPv6 egress blackholes their IPv6 traffic. See [Networking, NAT and Routing](Networking-NAT-and-Routing#ipv6) before enabling it.
+
+## docker-compose
+
+```yaml
+services:
+  ocserv:
+    image: azinchen/ocserv-server:latest
+    container_name: ocserv-server
+    restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    sysctls:
+      - net.ipv4.ip_forward=1
+    ports:
+      - 443:443/tcp
+      # - 443:443/udp   # only if you enable udp-port (DTLS) in ocserv.conf
+    environment:
+      - VPN_SUBNET=10.10.0.0/24   # must match ipv4-network above
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - ./volumes/config:/etc/ocserv
+```
+
+`NET_ADMIN`, the TUN device, and `ip_forward` are the minimum privileges ocserv needs — see [Configuration Reference](Configuration-Reference#capabilities-devices-sysctls). The VPN runs directly on host port 443 with nothing in front of it.
+
+## First run
+
+```bash
+docker compose up -d
+docker exec -it ocserv-server ocpasswd -c /etc/ocserv/ocpasswd alice   # create a user
+```
+
+## Connecting
+
+```bash
+sudo openconnect "https://vpn.example.com/?your-secret-here" --user=alice
+```
+
+Non-interactive:
+
+```bash
+echo "password" | sudo openconnect "https://vpn.example.com/?your-secret-here" \
+  --user=alice --passwd-on-stdin
+```
+
+The `/?your-secret-here` part is required because camouflage is on — without it the server answers like an ordinary website. See [[Camouflage Mode]].
+
+## What's next
+
+- [[User Management]] — adding and removing VPN users
+- [[Camouflage Mode]] — how the DPI bypass works
+- [[Networking NAT and Routing]] — full vs split tunnel

--- a/wiki/ocserv-Configuration-SWAG-Integration.md
+++ b/wiki/ocserv-Configuration-SWAG-Integration.md
@@ -1,0 +1,191 @@
+# ocserv Configuration: SWAG Integration
+
+The production setup when you already run [SWAG](https://github.com/linuxserver/docker-swag) — or any tool that automates Let's Encrypt. SWAG keeps a trusted, auto-renewing certificate; ocserv reads that certificate from a shared **read-only mount** and serves the VPN on its own port. The result is a browser-trusted VPN endpoint with hands-off certificate renewal.
+
+The key thing to understand up front: **SWAG never touches VPN traffic.** OpenConnect isn't an HTTP stream, so there's nothing for a reverse proxy to proxy. SWAG's entire role here is issuing and renewing the certificate file; ocserv is exposed directly on its own host port.
+
+```
+            ┌─────────────────────────────┐
+Client ───► │ host:8443 ──► ocserv (TLS)   │   ← VPN traffic, direct
+            └─────────────────────────────┘
+                       ▲ reads certs (ro)
+            ┌──────────┴──────────────────┐
+            │ SWAG  (issues/renews LE)     │   ← never sees VPN traffic
+            └─────────────────────────────┘
+```
+
+Because the only thing shared is the certificate *files*, ocserv does **not** join SWAG's Docker network — it just mounts SWAG's config directory read-only.
+
+The directives are explained in [[ocserv Configuration]]; this page covers the full config plus how the SWAG wiring and renewal work.
+
+## When to use this
+
+- You have a public domain and want a browser-trusted certificate
+- You already run SWAG (or want Let's Encrypt automation)
+- Another service already owns port 443, so ocserv needs its own port
+- You want the certificate to renew without you manually reloading ocserv
+
+If you'd rather point ocserv at standalone Let's Encrypt certs without SWAG in the picture, [Basic Standalone](ocserv-Configuration-Basic) is simpler.
+
+## Layout
+
+```
+/path/to/
+├── ocserv-server/                        # this project
+│   ├── docker-compose.yml
+│   └── volumes/
+│       └── config/
+│           ├── ocserv.conf               # the config below
+│           └── ocpasswd                  # user database
+│
+└── reverse-proxy/                        # SWAG container
+    └── volumes/
+        └── swag-config/
+            └── etc/letsencrypt/
+                └── live/vpn.example.com/
+                    ├── fullchain.pem
+                    └── privkey.pem
+```
+
+ocserv mounts SWAG's `swag-config` directory at `/swag-config` (read-only) and points its certificate directives into it.
+
+## The configuration
+
+Copy this to `volumes/config/ocserv.conf`. Change `camouflage_secret`, and set the certificate paths and `default-domain` to the domain SWAG issued the cert for.
+
+```ini
+# --- Ports (container-internal; the host maps 8443 -> these) ---
+tcp-port = 443
+# DTLS/UDP off by default — TCP-only is stealthier for camouflage and avoids
+# the Docker userland-proxy DTLS reconnect loop. To enable: uncomment and
+# publish 8443:443/udp in compose. See Configuration Reference.
+#udp-port = 443
+
+# --- Certificates (from SWAG; change the domain) ---
+server-cert = /swag-config/etc/letsencrypt/live/vpn.example.com/fullchain.pem
+server-key  = /swag-config/etc/letsencrypt/live/vpn.example.com/privkey.pem
+
+# --- Camouflage — CHANGE THE SECRET ---
+camouflage = true
+camouflage_secret = "change-me-to-a-long-random-secret"
+camouflage_realm = "Restricted Content"
+compression = false
+cookie-timeout = 300
+
+# --- Auth (local password file) ---
+auth = "plain[passwd=/etc/ocserv/ocpasswd]"
+
+# --- Hostname ---
+default-domain = vpn.example.com
+
+# --- Addressing (must match VPN_SUBNET in compose) ---
+device = vpns
+ipv4-network = 10.20.0.0
+ipv4-netmask = 255.255.255.0
+
+# --- Full-tunnel route ---
+route = default
+
+# --- DNS (forced through the tunnel to prevent leaks) ---
+tunnel-all-dns = true
+dns = 1.1.1.1
+dns = 9.9.9.9
+
+# --- Transport / sessions ---
+try-mtu-discovery = true
+dpd = 90
+mobile-dpd = 180
+keepalive = 300
+isolate-workers = true
+max-clients = 16
+max-same-clients = 2
+auth-timeout = 240
+idle-timeout = 0
+
+# --- Runtime + control socket ---
+pid-file    = /run/ocserv/ocserv.pid
+socket-file = /run/ocserv/ocserv.socket
+use-occtl = true
+occtl-socket-file = /var/run/occtl.socket
+
+# --- Privilege separation ---
+run-as-user = nobody
+run-as-group = daemon
+
+# --- Security & compatibility ---
+cisco-client-compat = true
+predictable-ips = true
+deny-roaming = false
+banner = "Welcome to OpenConnect VPN Server"
+```
+
+For a **wildcard** SWAG cert (`SUBDOMAINS=wildcard`), the `live/` directory is named after SWAG's main `URL` (e.g. `example.com`) and its SAN covers `vpn.example.com`. Confirm with:
+
+```bash
+openssl x509 -in fullchain.pem -noout -ext subjectAltName
+```
+
+## docker-compose
+
+```yaml
+services:
+  ocserv:
+    image: azinchen/ocserv-server:latest
+    container_name: ocserv-server
+    restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    sysctls:
+      - net.ipv4.ip_forward=1
+    ports:
+      - 8443:443/tcp          # own port; SWAG keeps 443
+      # - 8443:443/udp        # only if you enable udp-port (DTLS)
+    environment:
+      - VPN_SUBNET=10.20.0.0/24
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - ./volumes/config:/etc/ocserv
+      - ../reverse-proxy/volumes/swag-config:/swag-config:ro
+```
+
+No shared Docker network is defined — and none is needed. ocserv reaches the certificate through the read-only `/swag-config` mount, and serves clients directly on `8443`. SWAG continues to own `443` for everything else.
+
+## Auto-restart on certificate renewal
+
+ocserv loads certificates **at startup** and keeps them in memory. After SWAG renews the cert, ocserv keeps serving the old one until it restarts — so wire up a restart on renewal.
+
+Create `…/swag-config/etc/letsencrypt/renewal-hooks/post/restart-ocserv.sh`:
+
+```bash
+#!/bin/bash
+docker restart ocserv-server
+```
+
+Make it executable:
+
+```bash
+chmod +x .../swag-config/etc/letsencrypt/renewal-hooks/post/restart-ocserv.sh
+```
+
+SWAG runs hooks under `renewal-hooks/post/` after every successful renewal. Active sessions drop briefly during the restart, then clients reconnect.
+
+> The hook restarts a container, so it needs Docker access — either give the SWAG container the Docker socket, or run the hook on the host.
+
+See [[Reverse Proxy and Certificates]] for the broader certificate guide.
+
+## Connecting
+
+```bash
+echo "password" | sudo openconnect "https://vpn.example.com:8443/?your-secret-here" \
+  --user=username --passwd-on-stdin
+```
+
+Note the `:8443` (ocserv's own port) and the camouflage secret after `?`.
+
+## What's next
+
+- [[Reverse Proxy and Certificates]] — full SWAG/Let's Encrypt guide
+- [[User Management]] — adding VPN users
+- [[Camouflage Mode]] — how the DPI bypass works

--- a/wiki/ocserv-Configuration-Self-Signed.md
+++ b/wiki/ocserv-Configuration-Self-Signed.md
@@ -1,0 +1,198 @@
+# ocserv Configuration: Self-Signed (Testing)
+
+For development, labs, and quick proofs of concept where there's no public domain and no trusted certificate authority. You generate a throwaway certificate yourself and have clients trust it explicitly by **pinning** its fingerprint.
+
+This is deliberately **not** a production setup. A self-signed certificate makes [camouflage](Camouflage-Mode) pointless — an untrusted cert is itself a giveaway that something non-standard is running — and it forces every client to either pin the certificate or skip verification (which is unsafe). When you're ready for production, move to [Basic Standalone](ocserv-Configuration-Basic) or [SWAG Integration](ocserv-Configuration-SWAG-Integration) with a real certificate.
+
+What follows: how to generate a proper certificate, a complete working config, and how to connect with pinning.
+
+## When to use this
+
+- You're testing on a private network or a single machine
+- You have no public DNS name (clients connect by IP or a local hostname)
+- You want a self-contained, throwaway setup you can delete afterwards
+
+## Generating the certificate
+
+The single most common mistake here is omitting **Subject Alternative Names (SANs)**. A certificate must list every IP and hostname clients will actually connect to in its SAN field — modern clients (and ocserv) reject a cert where the connection target isn't in the SAN, regardless of the Common Name.
+
+**1. Create an OpenSSL config** (`san.conf`) — list your real targets under `[alt_names]`:
+
+```ini
+[req]
+default_bits = 2048
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+x509_extensions = v3_req
+prompt = no
+
+[req_distinguished_name]
+C  = US
+ST = State
+L  = City
+O  = Organization
+CN = vpn.local
+
+[v3_req]
+keyUsage = keyEncipherment, dataEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+
+[alt_names]
+IP.1  = 192.168.1.100
+IP.2  = 127.0.0.1
+DNS.1 = vpn.local
+DNS.2 = localhost
+```
+
+**2. Generate the cert and key:**
+
+```bash
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+  -keyout server-key.pem -out server-cert.pem \
+  -config san.conf
+
+chmod 600 server-key.pem
+chmod 644 server-cert.pem
+```
+
+**3. Verify the SAN actually made it in** (this is the step people skip):
+
+```bash
+openssl x509 -in server-cert.pem -noout -text | grep -A2 "Subject Alternative"
+```
+
+You should see your IPs/hostnames listed. If this is empty, clients will reject the cert.
+
+**4. Grab the fingerprint for client pinning:**
+
+```bash
+openssl x509 -in server-cert.pem -noout -fingerprint -sha256 | cut -d= -f2 | tr -d ':'
+```
+
+Save the output — clients pass it as `--servercert sha256:<fingerprint>`.
+
+## Layout
+
+```
+ocserv-server/
+├── docker-compose.yml
+└── volumes/
+    └── config/
+        ├── ocserv.conf          # the config below
+        ├── ocpasswd             # user database
+        ├── server-cert.pem      # self-signed certificate
+        └── server-key.pem       # private key
+```
+
+## The configuration
+
+Copy this to `volumes/config/ocserv.conf` and change the camouflage secret. The defaults here lean "lab": an obvious test subnet, public DNS, and IPv4-only.
+
+```ini
+# --- Ports (container-internal; the host maps 8443 -> these) ---
+tcp-port = 443
+#udp-port = 443   # DTLS off by default (TCP-only); see Configuration Reference
+
+# --- Self-signed certificate ---
+server-cert = /etc/ocserv/server-cert.pem
+server-key  = /etc/ocserv/server-key.pem
+
+# --- Camouflage — CHANGE THE SECRET ---
+camouflage = true
+camouflage_secret = "change-me-to-a-long-random-secret"
+camouflage_realm = "Restricted Content"
+compression = false
+cookie-timeout = 300
+
+# --- Auth (local password file) ---
+auth = "plain[passwd=/etc/ocserv/ocpasswd]"
+
+# --- Addressing (10.99.x is an obvious "test" range; must match VPN_SUBNET) ---
+device = vpns
+ipv4-network = 10.99.0.0
+ipv4-netmask = 255.255.255.0
+
+# --- Full-tunnel route ---
+route = default
+
+# --- DNS (broadly reachable from test networks) ---
+tunnel-all-dns = true
+dns = 8.8.8.8
+dns = 1.1.1.1
+
+# --- Transport / sessions ---
+try-mtu-discovery = true
+dpd = 90
+mobile-dpd = 180
+keepalive = 300
+isolate-workers = true
+max-clients = 16
+max-same-clients = 2
+auth-timeout = 240
+idle-timeout = 0
+
+# --- Runtime + control socket ---
+pid-file    = /run/ocserv/ocserv.pid
+socket-file = /run/ocserv/ocserv.socket
+use-occtl = true
+occtl-socket-file = /var/run/occtl.socket
+
+# --- Privilege separation ---
+run-as-user = nobody
+run-as-group = daemon
+
+# --- Security & compatibility ---
+cisco-client-compat = true
+predictable-ips = true
+deny-roaming = false
+banner = "Welcome to OpenConnect VPN Server"
+```
+
+It uses `10.99.0.0/24` so the VPN range won't collide with a typical home/office network, and stays IPv4-only to keep the lab simple.
+
+## docker-compose
+
+```yaml
+services:
+  ocserv:
+    image: azinchen/ocserv-server:latest
+    container_name: ocserv-vpn
+    restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    sysctls:
+      - net.ipv4.ip_forward=1
+    ports:
+      - 8443:443/tcp          # 8443 so it can coexist with a web server on 443
+    environment:
+      - VPN_SUBNET=10.99.0.0/24
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - ./volumes/config:/etc/ocserv
+```
+
+## Connecting — pin the cert
+
+Because the certificate isn't trusted by any CA, the client must **pin** it. Pinning is the safe choice: it accepts exactly your cert and nothing else. Avoid `--no-cert-check`, which accepts *any* certificate and leaves the connection open to a man-in-the-middle.
+
+```bash
+FPRINT=$(openssl x509 -noout -fingerprint -sha256 \
+  -in volumes/config/server-cert.pem | cut -d= -f2 | tr -d ':')
+
+echo "password" | sudo openconnect \
+  --servercert "sha256:$FPRINT" \
+  --user username \
+  --passwd-on-stdin \
+  "https://192.168.1.100:8443/?your-secret-here"
+```
+
+If the server IP or the certificate changes, regenerate the pin.
+
+## What's next
+
+- [[Camouflage Mode]] — why a trusted cert matters in production
+- [[Reverse Proxy and Certificates]] — moving to Let's Encrypt
+- [[Clients and Devices]] — client-specific pinning notes

--- a/wiki/ocserv-Configuration.md
+++ b/wiki/ocserv-Configuration.md
@@ -1,0 +1,135 @@
+# ocserv Configuration
+
+This page is about `ocserv.conf` — the VPN server's own configuration file, mounted at `/etc/ocserv/ocserv.conf`. For container-level settings (env vars, ports), see [[Configuration Reference]].
+
+## How the config gets there
+
+On startup the `init-config` service checks for `/etc/ocserv/ocserv.conf`. If it's **missing**, it copies a bundled default template into place. If it **exists**, it's left untouched. So:
+
+- Mount a `volumes/config` directory and drop your own `ocserv.conf` in — it wins.
+- Or start empty and let the template seed a baseline you then edit.
+
+The container launches ocserv as:
+
+```
+ocserv --foreground --config /etc/ocserv/ocserv.conf --log-stderr
+```
+
+After editing the config, **restart the container** (`docker restart ocserv-server`) for changes to take effect. Active sessions drop and clients reconnect.
+
+## Validate before you restart
+
+The image includes ocserv's config tester. Validate a config without starting the server:
+
+```bash
+docker run --rm \
+  -v ./volumes/config:/etc/ocserv:ro \
+  --entrypoint /usr/sbin/ocserv \
+  azinchen/ocserv-server:latest \
+  -t -c /etc/ocserv/ocserv.conf
+```
+
+Lines beginning with `note:` are informational. Anything else (`error:`) is a real problem — fix it before restarting.
+
+## Start from a configuration variant
+
+Three maintained, validated configurations are documented in their own pages. Pick the one that matches your deployment:
+
+- **Standalone** — see [Basic Standalone](ocserv-Configuration-Basic)
+- **Self-signed certs (testing only)** — see [Self-Signed](ocserv-Configuration-Self-Signed)
+- **Behind SWAG / Let's Encrypt** — see [SWAG Integration](ocserv-Configuration-SWAG-Integration)
+
+## Key directives explained
+
+A tour of the directives you're most likely to change. The full reference is in ocserv's own documentation, but these are the load-bearing ones for this image.
+
+### Listening
+
+```ini
+tcp-port = 443
+udp-port = 443      # omit to disable DTLS (TCP-only)
+```
+
+These are **container-internal** ports. The host mapping (e.g. `8443:443`) is separate.
+
+### Certificates
+
+```ini
+server-cert = /etc/ocserv/server-cert.pem
+server-key  = /etc/ocserv/server-key.pem
+```
+
+Point these wherever your certs live inside the container. With SWAG, they live under `/swag-config/...` — see [[Reverse Proxy and Certificates]].
+
+### Authentication
+
+```ini
+auth = "plain[passwd=/etc/ocserv/ocpasswd]"
+```
+
+Password-file auth backed by `ocpasswd`. See [[User Management]]. ocserv also supports PAM, RADIUS, GSSAPI, and certificate auth.
+
+### Addressing
+
+```ini
+device = vpns
+ipv4-network = 10.20.0.0
+ipv4-netmask = 255.255.255.0
+```
+
+The `ipv4-network` here **must** line up with the container's `VPN_SUBNET` env var so NAT masquerades the right range. `device = vpns` produces `vpns0`, `vpns1`, … matching `VPN_IF=vpns+`.
+
+### Routes (full vs split tunnel)
+
+```ini
+route = default          # full tunnel: send all client traffic through the VPN
+# route = 10.0.0.0/8     # split tunnel: only specific networks
+```
+
+See [Networking NAT and Routing](Networking-NAT-and-Routing#full-vs-split-tunnel).
+
+### DNS
+
+```ini
+tunnel-all-dns = true    # force clients to use the pushed DNS (prevents leaks)
+dns = 1.1.1.1
+dns = 9.9.9.9
+```
+
+### Camouflage
+
+```ini
+camouflage = true
+camouflage_secret = "a-long-random-secret"
+camouflage_realm  = "Restricted Content"
+```
+
+See [[Camouflage Mode]].
+
+### Privilege separation & runtime
+
+```ini
+run-as-user  = nobody
+run-as-group = daemon
+pid-file     = /run/ocserv/ocserv.pid
+socket-file  = /run/ocserv/ocserv.socket
+use-occtl    = true
+occtl-socket-file = /var/run/occtl.socket
+```
+
+The container creates `/run/ocserv` before launch, so these paths work out of the box. `use-occtl = true` enables the [occtl](User-Management#monitoring-with-occtl) control socket.
+
+### Sessions & compatibility
+
+```ini
+max-clients = 16
+max-same-clients = 2
+cisco-client-compat = true   # AnyConnect / many routers
+compression = false          # safer (avoids compression-oracle attacks)
+dpd = 90                     # dead-peer detection
+keepalive = 300
+```
+
+---
+
+Next: **[[User Management]]** · **[[Camouflage Mode]]**


### PR DESCRIPTION
## Summary

- Remove the `wiki` git submodule (`.gitmodules` deleted) and track all 19 wiki pages directly in `wiki/`, so wiki changes can go through normal PRs in this repo.
- Add `.github/workflows/wiki-publish.yml` (**Docs - Publish Wiki**), which mirrors `wiki/` into the GitHub wiki repository and pushes directly to its `master` branch.

## Workflow behavior

- **Triggers:** every tag (release) push, plus `workflow_dispatch` from any branch or tag.
- **Sync:** `rsync --delete` makes the wiki repo exactly mirror `wiki/` (adds, replaces, and deletes pages).
- **Versioned history:** commits are titled `Publish wiki for <version>`; when content is unchanged an empty marker commit is still pushed so every release is recorded in the wiki history. For manual runs on a branch the version is `<branch>@<short-sha>`.
- **Auth:** uses the built-in `GITHUB_TOKEN` (`contents: write`) to push to `<repo>.wiki.git` — no extra secrets needed.

## Notes

- Wiki content is unchanged; it is the current submodule state (`3c417f8`).