### PR TITLE
feat: per-user gateway routing via VPN_GATEWAYS and VPN_USER_GATEWAY

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ You provide an `ocserv.conf` and a certificate in the config volume. Ready-to-us
 | `VPN_GATEWAY6` | _(unset)_ | IPv6 gateway for gateway mode. If set, the IPv6 client subnet is policy-routed to it; if unset, forwarded client IPv6 is **dropped** to prevent leaks. |
 | `VPN_GATEWAY_TABLE` | `100` | Routing table used for gateway mode. |
 | `VPN_GATEWAY_RULE_PRIO` | `1000` | Priority of the `from <VPN_SUBNET>` policy rule. |
+| `VPN_GATEWAYS` | _(unset)_ | Named upstream gateways for per-user routing, e.g. `nl=172.28.0.2,us=172.28.0.4`. Each gets its own routing table and kill-switch set. |
+| `VPN_GATEWAYS6` | _(unset)_ | Optional IPv6 address per gateway name, e.g. `nl=fd00::2`. A name without one has its users' forwarded IPv6 dropped (fail-closed). |
+| `VPN_USER_GATEWAY` | _(unset)_ | Username → gateway name map, e.g. `user1=nl,user2=us`. Unmapped users follow `VPN_GATEWAY` (or the default route if unset); the reserved name `direct` bypasses `VPN_GATEWAY`. |
+| `VPN_GATEWAY_USER_RULE_PRIO` | `900` | Priority of the per-user policy rules (must be lower than `VPN_GATEWAY_RULE_PRIO` to win). |
 
 Full reference: [Configuration Reference](https://github.com/azinchen/ocserv-server/wiki/Configuration-Reference).
 
@@ -81,6 +85,11 @@ and ocserv policy-routes its client subnet out through it — clients exit with 
 upstream's IP. A fail-closed nft kill switch ensures client traffic can only leave
 toward the gateway (no leak if the upstream tunnel drops). Add `VPN_GATEWAY6` to do
 the same for IPv6. See [Gateway Mode](https://github.com/azinchen/ocserv-server/wiki/Gateway-Mode).
+
+Different users can exit through different gateways: define named gateways with
+`VPN_GATEWAYS` and map users to them with `VPN_USER_GATEWAY` (e.g.
+`user1=nl,user2=us`). Rules are installed per session on connect, so no static IP
+assignment is needed, and every path keeps the fail-closed kill switch.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You provide an `ocserv.conf` and a certificate in the config volume. Ready-to-us
 | `VPN_GATEWAY_RULE_PRIO` | `1000` | Priority of the `from <VPN_SUBNET>` policy rule. |
 | `VPN_GATEWAYS` | _(unset)_ | Named upstream gateways for per-user routing, e.g. `nl=172.28.0.2,us=172.28.0.4`. Each gets its own routing table and kill-switch set. |
 | `VPN_GATEWAYS6` | _(unset)_ | Optional IPv6 address per gateway name, e.g. `nl=fd00::2`. A name without one has its users' forwarded IPv6 dropped (fail-closed). |
-| `VPN_USER_GATEWAY` | _(unset)_ | Username → gateway name map, e.g. `user1=nl,user2=us`. Unmapped users follow `VPN_GATEWAY` (or the default route if unset); the reserved name `direct` bypasses `VPN_GATEWAY`. |
+| `VPN_USER_GATEWAY` | _(unset)_ | Username → gateway name map, e.g. `user1=nl,user2=us`. Unmapped users follow `VPN_GATEWAY` (or the default route if unset); the reserved name `direct` sends a user out the container's default route (the ISP) even when `VPN_GATEWAY` is set. `VPN_GATEWAY=direct` is accepted as an explicit "no default gateway". |
 | `VPN_GATEWAY_USER_RULE_PRIO` | `900` | Priority of the per-user policy rules (must be lower than `VPN_GATEWAY_RULE_PRIO` to win). |
 
 Full reference: [Configuration Reference](https://github.com/azinchen/ocserv-server/wiki/Configuration-Reference).

--- a/rootfs/etc/s6-overlay/s6-rc.d/init-vpngw/dependencies
+++ b/rootfs/etc/s6-overlay/s6-rc.d/init-vpngw/dependencies
@@ -1,1 +1,2 @@
 init-nat
+init-config

--- a/rootfs/etc/s6-overlay/s6-rc.d/init-vpngw/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/init-vpngw/run
@@ -14,58 +14,169 @@ set -eu
 # route: only packets FROM the client subnet are steered to the gateway. The
 # routing decision happens before init-nat's masquerade, so the "from <subnet>"
 # match still sees the real client source address.
+#
+# Two layers are supported and can be combined:
+#   * VPN_GATEWAY / VPN_GATEWAY6           - default gateway for the whole subnet
+#   * VPN_GATEWAYS + VPN_USER_GATEWAY      - per-user gateways: named gateways get
+#     their own routing table and kill-switch set here; the actual per-session
+#     rules are added/removed by /usr/local/bin/ocserv-vpngw-script, which ocserv
+#     runs on client connect/disconnect (the session's source IP is only known
+#     then). Users not listed in VPN_USER_GATEWAY follow VPN_GATEWAY if set,
+#     otherwise the container's default route. The reserved gateway name
+#     "direct" sends a user out the default route even when VPN_GATEWAY is set.
 
-if [ -z "${vpn_gateway:-}" ]; then
-    log "[INIT-VPNGW] VPN_GATEWAY not set; clients exit via the default route"
+conf=/etc/ocserv/ocserv.conf
+
+# Undo our managed edits in ocserv.conf (managed block + commented-out user
+# hooks). Only touches the file if our markers are present.
+restore_config() {
+    [ -f "$conf" ] || return 0
+    if grep -q 'ocserv-vpngw managed block' "$conf" || grep -q '^#\[vpngw\]# ' "$conf"; then
+        sed -i '/^# BEGIN ocserv-vpngw managed block/,/^# END ocserv-vpngw managed block/d' "$conf"
+        sed -i 's/^#\[vpngw\]# //' "$conf"
+        log "[INIT-VPNGW] Removed managed connect-script hooks from ocserv.conf"
+    fi
+}
+
+rm -rf "$vpngw_state_dir"
+
+if [ -z "$vpn_gateway" ] && [ -z "$vpn_gateways" ]; then
+    restore_config
+    log "[INIT-VPNGW] VPN_GATEWAY/VPN_GATEWAYS not set; clients exit via the default route"
     exit 0
 fi
+
+mkdir -p "$vpngw_state_dir"
 
 table="$vpn_gateway_table"
 prio="$vpn_gateway_rule_prio"
 
-# ---- IPv4 routing --------------------------------------------------------
-log "[INIT-VPNGW] Routing $vpn_subnet via $vpn_gateway (table $table)"
-ip route replace default via "$vpn_gateway" table "$table"
-ip rule show | grep -q "from $vpn_subnet lookup $table" \
-    || ip rule add from "$vpn_subnet" lookup "$table" priority "$prio"
+# ---- Named gateways (per-user routing tables) ------------------------------
+if [ -n "$vpn_gateways" ]; then
+    kv_pairs "$vpn_gateways" > "$vpngw_state_dir/gateways.tmp"
+    idx=0
+    while read -r name gw4; do
+        case "$name" in
+            direct)
+                log_error "[INIT-VPNGW] VPN_GATEWAYS: 'direct' is a reserved gateway name"
+                exit 1
+                ;;
+            *[!a-zA-Z0-9_]*)
+                log_error "[INIT-VPNGW] VPN_GATEWAYS: invalid gateway name '$name' (use letters, digits, _)"
+                exit 1
+                ;;
+        esac
+        idx=$((idx + 1))
+        gw_table=$((vpn_gateway_table + idx))
+        gw6="$(kv_get "$vpn_gateways6" "$name")"
+        log "[INIT-VPNGW] Gateway '$name': table $gw_table via $gw4${gw6:+ / $gw6}"
+        ip route replace default via "$gw4" table "$gw_table"
+        if [ -n "$gw6" ]; then
+            ip -6 route replace default via "$gw6" table "$gw_table" \
+                || log_error "[INIT-VPNGW] Warning: could not add IPv6 route for gateway '$name'"
+        fi
+        printf '%s %s %s %s\n' "$name" "$gw_table" "$gw4" "${gw6:--}" >> "$vpngw_state_dir/gateways"
+    done < "$vpngw_state_dir/gateways.tmp"
+    rm -f "$vpngw_state_dir/gateways.tmp"
+fi
 
-# ---- IPv6 routing (only if an upstream v6 gateway is provided) ------------
-if [ -n "${vpn_gateway6:-}" ]; then
-    log "[INIT-VPNGW] Routing $ipv6_subnet via $vpn_gateway6 (table $table)"
-    ip -6 route replace default via "$vpn_gateway6" table "$table" \
-        || log_error "[INIT-VPNGW] Warning: could not add IPv6 gateway route"
-    ip -6 rule show 2>/dev/null | grep -q "from $ipv6_subnet lookup $table" \
-        || ip -6 rule add from "$ipv6_subnet" lookup "$table" priority "$prio" \
-        || log_error "[INIT-VPNGW] Warning: could not add IPv6 policy rule"
+# ---- Per-user map validation ----------------------------------------------
+if [ -n "$vpn_user_gateway" ]; then
+    kv_pairs "$vpn_user_gateway" > "$vpngw_state_dir/users.tmp"
+    while read -r user gwname; do
+        if [ "$gwname" != "direct" ] \
+            && ! awk -v n="$gwname" '$1 == n { found = 1 } END { exit !found }' \
+                "$vpngw_state_dir/gateways" 2>/dev/null; then
+            log_error "[INIT-VPNGW] VPN_USER_GATEWAY: unknown gateway '$gwname' for user '$user' (define it in VPN_GATEWAYS)"
+            exit 1
+        fi
+        log "[INIT-VPNGW] User '$user' routes via gateway '$gwname'"
+        printf '%s %s\n' "$user" "$gwname" >> "$vpngw_state_dir/users"
+    done < "$vpngw_state_dir/users.tmp"
+    rm -f "$vpngw_state_dir/users.tmp"
+fi
+
+# ---- Default gateway: IPv4 routing -----------------------------------------
+if [ -n "$vpn_gateway" ]; then
+    log "[INIT-VPNGW] Routing $vpn_subnet via $vpn_gateway (table $table)"
+    ip route replace default via "$vpn_gateway" table "$table"
+    ip rule show | grep -q "from $vpn_subnet lookup $table" \
+        || ip rule add from "$vpn_subnet" lookup "$table" priority "$prio"
+
+    # ---- Default gateway: IPv6 routing (only with an upstream v6 gateway) ---
+    if [ -n "${vpn_gateway6:-}" ]; then
+        log "[INIT-VPNGW] Routing $ipv6_subnet via $vpn_gateway6 (table $table)"
+        ip -6 route replace default via "$vpn_gateway6" table "$table" \
+            || log_error "[INIT-VPNGW] Warning: could not add IPv6 gateway route"
+        ip -6 rule show 2>/dev/null | grep -q "from $ipv6_subnet lookup $table" \
+            || ip -6 rule add from "$ipv6_subnet" lookup "$table" priority "$prio" \
+            || log_error "[INIT-VPNGW] Warning: could not add IPv6 policy rule"
+    fi
 fi
 
 # ---- Kill switch (defense in depth) --------------------------------------
-# The policy route already forces client traffic to the gateway, but if that
+# The policy routes already force client traffic to the gateways, but if a
 # route is ever missing the kernel would fall through to the main table and leak
 # out the WAN. These nft rules make that explicit and fail-closed:
-#   * IPv4: allow client traffic out the WAN ONLY toward the gateway next-hop;
-#           drop anything else (e.g. a fall-through to the docker bridge).
-#   * IPv6 with a v6 gateway: same next-hop guard as IPv4.
-#   * IPv6 without a v6 gateway: no v6 path, so drop forwarded client v6 outright
-#           (otherwise it would bypass the v4-only policy rule).
+#   * Per-user gateways: each named gateway gets an address set (filled by the
+#     connect hook); traffic from those addresses may exit the WAN ONLY toward
+#     that gateway's next-hop and never falls through to the default guard.
+#   * "direct" users: an accept set so they bypass the default guard.
+#   * v6_drop: forwarded IPv6 from users whose gateway has no IPv6 is dropped
+#     outright (otherwise it would bypass the v4-only policy rule).
+#   * Default gateway (IPv4/IPv6): same next-hop guard for the whole subnet.
 case "$vpn_if" in
     *+) vpn_ifname="${vpn_if%+}*" ;;
     *)  vpn_ifname="$vpn_if" ;;
 esac
 
-if [ -n "${vpn_gateway6:-}" ]; then
-    killswitch6="ip6 saddr $ipv6_subnet oifname \"$wan_if\" rt ip6 nexthop != $vpn_gateway6 drop"
-else
-    killswitch6="meta nfproto ipv6 iifname \"$vpn_ifname\" drop"
+nft_sets=""
+user_rules=""
+if [ -f "$vpngw_state_dir/gateways" ]; then
+    while read -r name gw_table gw4 gw6; do
+        nft_sets="$nft_sets
+    set gw_${name}_v4 { type ipv4_addr; }"
+        user_rules="$user_rules
+        ip saddr @gw_${name}_v4 oifname \"$wan_if\" rt ip nexthop != $gw4 drop
+        ip saddr @gw_${name}_v4 oifname \"$wan_if\" accept"
+        if [ "$gw6" != "-" ]; then
+            nft_sets="$nft_sets
+    set gw_${name}_v6 { type ipv6_addr; }"
+            user_rules="$user_rules
+        ip6 saddr @gw_${name}_v6 oifname \"$wan_if\" rt ip6 nexthop != $gw6 drop
+        ip6 saddr @gw_${name}_v6 oifname \"$wan_if\" accept"
+        fi
+    done < "$vpngw_state_dir/gateways"
+fi
+if [ -f "$vpngw_state_dir/users" ]; then
+    nft_sets="$nft_sets
+    set direct_v4 { type ipv4_addr; }
+    set direct_v6 { type ipv6_addr; }
+    set v6_drop { type ipv6_addr; }"
+    user_rules="$user_rules
+        ip saddr @direct_v4 oifname \"$wan_if\" accept
+        ip6 saddr @direct_v6 oifname \"$wan_if\" accept
+        ip6 saddr @v6_drop drop"
+fi
+
+default_rules=""
+if [ -n "$vpn_gateway" ]; then
+    default_rules="ip saddr $vpn_subnet oifname \"$wan_if\" rt ip nexthop != $vpn_gateway drop"
+    if [ -n "${vpn_gateway6:-}" ]; then
+        default_rules="$default_rules
+        ip6 saddr $ipv6_subnet oifname \"$wan_if\" rt ip6 nexthop != $vpn_gateway6 drop"
+    else
+        default_rules="$default_rules
+        meta nfproto ipv6 iifname \"$vpn_ifname\" drop"
+    fi
 fi
 
 nft delete table inet ocserv_gw 2>/dev/null || true
 if nft -f - <<EOF
-table inet ocserv_gw {
+table inet ocserv_gw {$nft_sets
     chain forward {
-        type filter hook forward priority -10; policy accept;
-        ip saddr $vpn_subnet oifname "$wan_if" rt ip nexthop != $vpn_gateway drop
-        $killswitch6
+        type filter hook forward priority -10; policy accept;$user_rules
+        $default_rules
     }
 }
 EOF
@@ -73,6 +184,39 @@ then
     log "[INIT-VPNGW] Kill-switch installed (table inet ocserv_gw)"
 else
     log_error "[INIT-VPNGW] Warning: kill-switch nft rules failed to load; relying on policy routing only"
+fi
+
+# ---- ocserv connect/disconnect hook ---------------------------------------
+# Per-user rules can only be installed when a session gets its IP, so ocserv
+# must run our hook on connect/disconnect. We manage the config directives
+# ourselves: an existing user-configured script is commented out (with a
+# restore marker), recorded in the state dir, and chain-called by our hook.
+if [ -f "$vpngw_state_dir/users" ]; then
+    if [ ! -f "$conf" ]; then
+        log_error "[INIT-VPNGW] $conf not found; cannot install connect-script hook"
+        exit 1
+    fi
+    restore_config
+    orig_connect="$(sed -n 's/^connect-script[[:space:]]*=[[:space:]]*//p' "$conf" | head -1 | tr -d '"')"
+    orig_disconnect="$(sed -n 's/^disconnect-script[[:space:]]*=[[:space:]]*//p' "$conf" | head -1 | tr -d '"')"
+    if [ -n "$orig_connect" ]; then
+        printf '%s\n' "$orig_connect" > "$vpngw_state_dir/user-connect-script"
+        log "[INIT-VPNGW] Chaining existing connect-script: $orig_connect"
+    fi
+    if [ -n "$orig_disconnect" ]; then
+        printf '%s\n' "$orig_disconnect" > "$vpngw_state_dir/user-disconnect-script"
+        log "[INIT-VPNGW] Chaining existing disconnect-script: $orig_disconnect"
+    fi
+    sed -i 's/^connect-script[[:space:]]*=/#[vpngw]# &/; s/^disconnect-script[[:space:]]*=/#[vpngw]# &/' "$conf"
+    cat >> "$conf" <<'EOF'
+# BEGIN ocserv-vpngw managed block (added by init-vpngw; do not edit)
+connect-script = /usr/local/bin/ocserv-vpngw-script
+disconnect-script = /usr/local/bin/ocserv-vpngw-script
+# END ocserv-vpngw managed block
+EOF
+    log "[INIT-VPNGW] Installed connect/disconnect hook in ocserv.conf"
+else
+    restore_config
 fi
 
 log "[INIT-VPNGW] Gateway routing active"

--- a/rootfs/etc/s6-overlay/s6-rc.d/init-vpngw/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/init-vpngw/run
@@ -27,6 +27,11 @@ set -eu
 
 conf=/etc/ocserv/ocserv.conf
 
+# VPN_GATEWAY=direct is an explicit alias for "no default gateway": unmapped
+# users exit via the container's default route (the ISP)
+[ "$vpn_gateway" = "direct" ] && vpn_gateway=""
+[ "$vpn_gateway6" = "direct" ] && vpn_gateway6=""
+
 # Undo our managed edits in ocserv.conf (managed block + commented-out user
 # hooks). Only touches the file if our markers are present.
 restore_config() {

--- a/rootfs/usr/local/bin/backend-functions
+++ b/rootfs/usr/local/bin/backend-functions
@@ -10,6 +10,13 @@ vpn_gateway="${VPN_GATEWAY:-}"
 vpn_gateway6="${VPN_GATEWAY6:-}"
 vpn_gateway_table="${VPN_GATEWAY_TABLE:-100}"
 vpn_gateway_rule_prio="${VPN_GATEWAY_RULE_PRIO:-1000}"
+vpn_gateways="${VPN_GATEWAYS:-}"
+vpn_gateways6="${VPN_GATEWAYS6:-}"
+vpn_user_gateway="${VPN_USER_GATEWAY:-}"
+vpn_gateway_user_rule_prio="${VPN_GATEWAY_USER_RULE_PRIO:-900}"
+
+# Runtime state shared between init-vpngw and the ocserv connect/disconnect hook
+vpngw_state_dir="/run/ocserv-vpngw"
 ipv6_forward="${IPV6_FORWARD:-1}"
 ipv6_nat="${IPV6_NAT:-0}"
 ipv6_subnet="${IPV6_SUBNET:-fda9:4efe:7e3b:03ea::/64}"
@@ -21,4 +28,16 @@ log() {
 
 log_error() {
     echo "$(date '+%Y-%m-%d %H:%M:%S') $1" >&2
+}
+
+# Print "key value" lines from a "key=value,key=value" list
+kv_pairs() {
+    [ -n "${1:-}" ] || return 0
+    echo "$1" | tr ',' '\n' | \
+        awk -F= '{ gsub(/[[:space:]]/, "") } $1 != "" && $2 != "" { print $1 " " $2 }'
+}
+
+# Print the value for a key in a "key=value,key=value" list (empty if absent)
+kv_get() {
+    kv_pairs "${1:-}" | awk -v k="$2" '$1 == k { print $2; exit }'
 }

--- a/rootfs/usr/local/bin/ocserv-vpngw-script
+++ b/rootfs/usr/local/bin/ocserv-vpngw-script
@@ -1,0 +1,138 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# ocserv connect/disconnect hook for per-user gateway routing (VPN_USER_GATEWAY).
+#
+# ocserv runs this script with the session in the environment: REASON
+# (connect|disconnect), USERNAME, IP_REMOTE (assigned IPv4) and IPV6_REMOTE
+# (assigned IPv6, if any). On connect we install a source policy rule steering
+# the session's address to its gateway's routing table and register the address
+# in the matching kill-switch set; on disconnect we remove them. State written
+# by init-vpngw lives in $vpngw_state_dir:
+#   gateways               "name table gw4 gw6|-" per named gateway
+#   users                  "username gwname" per mapped user
+#   user-connect-script    original user hook to chain-call (optional)
+#   user-disconnect-script original user hook to chain-call (optional)
+#
+# Fail-closed: if the routing rule or kill-switch entry cannot be installed on
+# connect, we exit non-zero so ocserv REJECTS the session instead of letting the
+# user's traffic fall through to the default gateway.
+
+set -u
+
+. /usr/local/bin/backend-functions
+
+reason="${REASON:-}"
+username="${USERNAME:-}"
+ip4="${IP_REMOTE:-}"
+ip6="${IPV6_REMOTE:-}"
+ip6="${ip6%%/*}"
+prio="$vpn_gateway_user_rule_prio"
+
+# Chain-call the user's original connect/disconnect script, if one was
+# configured in ocserv.conf before we installed our hook.
+run_user_script() {
+    script_file="$vpngw_state_dir/user-$reason-script"
+    [ -f "$script_file" ] || return 0
+    user_script="$(cat "$script_file")"
+    [ -n "$user_script" ] || return 0
+    "$user_script"
+}
+
+# Remove every policy rule and kill-switch entry for this session's addresses.
+# Used on disconnect and as stale-state cleanup before connect, so an address
+# can never keep a previous session's gateway.
+cleanup_session() {
+    if [ -n "$ip4" ]; then
+        n=0
+        while [ "$n" -lt 16 ] && ip rule del from "$ip4" priority "$prio" 2>/dev/null; do
+            n=$((n + 1))
+        done
+        nft delete element inet ocserv_gw direct_v4 "{ $ip4 }" 2>/dev/null || true
+    fi
+    if [ -n "$ip6" ]; then
+        n=0
+        while [ "$n" -lt 16 ] && ip -6 rule del from "$ip6" priority "$prio" 2>/dev/null; do
+            n=$((n + 1))
+        done
+        nft delete element inet ocserv_gw direct_v6 "{ $ip6 }" 2>/dev/null || true
+        nft delete element inet ocserv_gw v6_drop "{ $ip6 }" 2>/dev/null || true
+    fi
+    if [ -f "$vpngw_state_dir/gateways" ]; then
+        while read -r name _ _ gw6; do
+            [ -n "$ip4" ] \
+                && { nft delete element inet ocserv_gw "gw_${name}_v4" "{ $ip4 }" 2>/dev/null || true; }
+            [ "$gw6" != "-" ] && [ -n "$ip6" ] \
+                && { nft delete element inet ocserv_gw "gw_${name}_v6" "{ $ip6 }" 2>/dev/null || true; }
+        done < "$vpngw_state_dir/gateways"
+    fi
+    return 0
+}
+
+fail_closed() {
+    log_error "[VPNGW-HOOK] $1 (user '$username', ip $ip4); rejecting session"
+    cleanup_session
+    exit 1
+}
+
+# Feature disabled or user not mapped: nothing to do beyond the user's own hook
+if [ ! -f "$vpngw_state_dir/users" ] || [ -z "$username" ]; then
+    run_user_script
+    exit $?
+fi
+gwname="$(awk -v u="$username" '$1 == u { print $2; exit }' "$vpngw_state_dir/users")"
+if [ -z "$gwname" ]; then
+    run_user_script
+    exit $?
+fi
+
+case "$reason" in
+    connect)
+        [ -n "$ip4" ] || fail_closed "no IP_REMOTE in connect event"
+        cleanup_session
+        if [ "$gwname" = "direct" ]; then
+            nft add element inet ocserv_gw direct_v4 "{ $ip4 }" \
+                || fail_closed "cannot add direct_v4 kill-switch entry"
+            if [ -n "$ip6" ]; then
+                nft add element inet ocserv_gw direct_v6 "{ $ip6 }" \
+                    || fail_closed "cannot add direct_v6 kill-switch entry"
+            fi
+            log "[VPNGW-HOOK] User '$username' ($ip4${ip6:+, $ip6}) exits via default route"
+        else
+            gw_line="$(awk -v n="$gwname" '$1 == n { print; exit }' "$vpngw_state_dir/gateways")"
+            [ -n "$gw_line" ] || fail_closed "gateway '$gwname' not found in state"
+            gw_table="$(echo "$gw_line" | awk '{ print $2 }')"
+            gw6="$(echo "$gw_line" | awk '{ print $4 }')"
+            ip rule add from "$ip4" lookup "$gw_table" priority "$prio" \
+                || fail_closed "cannot add policy rule for gateway '$gwname'"
+            nft add element inet ocserv_gw "gw_${gwname}_v4" "{ $ip4 }" \
+                || fail_closed "cannot add kill-switch entry for gateway '$gwname'"
+            if [ -n "$ip6" ]; then
+                if [ "$gw6" != "-" ]; then
+                    ip -6 rule add from "$ip6" lookup "$gw_table" priority "$prio" \
+                        || fail_closed "cannot add IPv6 policy rule for gateway '$gwname'"
+                    nft add element inet ocserv_gw "gw_${gwname}_v6" "{ $ip6 }" \
+                        || fail_closed "cannot add IPv6 kill-switch entry for gateway '$gwname'"
+                else
+                    # Gateway has no IPv6: drop this session's forwarded IPv6 so
+                    # it cannot bypass the IPv4-only policy rule
+                    nft add element inet ocserv_gw v6_drop "{ $ip6 }" \
+                        || fail_closed "cannot add v6_drop kill-switch entry"
+                fi
+            fi
+            log "[VPNGW-HOOK] User '$username' ($ip4${ip6:+, $ip6}) routed via gateway '$gwname' (table $gw_table)"
+        fi
+        run_user_script
+        exit $?
+        ;;
+    disconnect)
+        cleanup_session
+        log "[VPNGW-HOOK] User '$username' ($ip4${ip6:+, $ip6}) gateway rules removed"
+        run_user_script || true
+        exit 0
+        ;;
+    *)
+        run_user_script
+        exit $?
+        ;;
+esac

--- a/rootfs/usr/local/bin/ocserv-vpngw-script
+++ b/rootfs/usr/local/bin/ocserv-vpngw-script
@@ -91,9 +91,15 @@ case "$reason" in
         [ -n "$ip4" ] || fail_closed "no IP_REMOTE in connect event"
         cleanup_session
         if [ "$gwname" = "direct" ]; then
+            # Steer the session to the main table so it escapes the
+            # subnet-wide VPN_GATEWAY rule and exits via the default route
+            ip rule add from "$ip4" lookup main priority "$prio" \
+                || fail_closed "cannot add direct policy rule"
             nft add element inet ocserv_gw direct_v4 "{ $ip4 }" \
                 || fail_closed "cannot add direct_v4 kill-switch entry"
             if [ -n "$ip6" ]; then
+                ip -6 rule add from "$ip6" lookup main priority "$prio" \
+                    || fail_closed "cannot add direct IPv6 policy rule"
                 nft add element inet ocserv_gw direct_v6 "{ $ip6 }" \
                     || fail_closed "cannot add direct_v6 kill-switch entry"
             fi

--- a/wiki/Configuration-Reference.md
+++ b/wiki/Configuration-Reference.md
@@ -14,13 +14,13 @@ These are read by the container's startup scripts (`backend-functions`) and driv
 | `IPV6_FORWARD` | `1` | Enable IPv6 forwarding sysctl inside the container. |
 | `IPV6_NAT` | `0` | Enable IPv6 masquerade for `IPV6_SUBNET`. Off by default — see the IPv6 warning below. |
 | `IPV6_SUBNET` | `fda9:4efe:7e3b:03ea::/64` | IPv6 ULA subnet to masquerade when `IPV6_NAT=1`. |
-| `VPN_GATEWAY` | _(unset)_ | Route the client subnet out through an upstream gateway container (e.g. a NordVPN container) instead of straight out the WAN. Set to the gateway's IP. Adds a fail-closed kill switch. See [[Gateway Mode]]. |
+| `VPN_GATEWAY` | _(unset)_ | Route the client subnet out through an upstream gateway container (e.g. a NordVPN container) instead of straight out the WAN. Set to the gateway's IP. Adds a fail-closed kill switch. The value `direct` is accepted as an explicit "no gateway" (same as unset). See [[Gateway Mode]]. |
 | `VPN_GATEWAY6` | _(unset)_ | Upstream IPv6 gateway. Set to route the IPv6 client subnet through it; unset means forwarded client IPv6 is dropped. See [[Gateway Mode]]. |
 | `VPN_GATEWAY_TABLE` | `100` | Routing table used for the gateway default route. Named gateways from `VPN_GATEWAYS` use the following tables (101, 102, …). |
 | `VPN_GATEWAY_RULE_PRIO` | `1000` | Priority of the `from <VPN_SUBNET>` policy rule. |
 | `VPN_GATEWAYS` | _(unset)_ | Named upstream gateways for per-user routing, e.g. `nl=172.28.0.2,us=172.28.0.4`. See [Gateway Mode#per-user-gateways](Gateway-Mode#per-user-gateways). |
 | `VPN_GATEWAYS6` | _(unset)_ | Optional IPv6 address per gateway name, e.g. `nl=fd00::2`. A gateway without one has its users' forwarded IPv6 dropped (fail-closed). |
-| `VPN_USER_GATEWAY` | _(unset)_ | Username → gateway name map, e.g. `user1=nl,user2=us`. Unmapped users follow `VPN_GATEWAY` or the default route; the reserved name `direct` bypasses `VPN_GATEWAY`. |
+| `VPN_USER_GATEWAY` | _(unset)_ | Username → gateway name map, e.g. `user1=nl,user2=us`. Unmapped users follow `VPN_GATEWAY` or the default route; the reserved name `direct` sends a user out the container's default route (the ISP) even when `VPN_GATEWAY` is set. |
 | `VPN_GATEWAY_USER_RULE_PRIO` | `900` | Priority of the per-user policy rules; must be numerically lower (= stronger) than `VPN_GATEWAY_RULE_PRIO`. |
 
 > **About `PUID`/`PGID`:** this image does **not** implement LinuxServer-style `PUID`/`PGID` user remapping. Setting them has no effect; ocserv drops privileges internally via the `run-as-user`/`run-as-group` directives in `ocserv.conf`.

--- a/wiki/Configuration-Reference.md
+++ b/wiki/Configuration-Reference.md
@@ -16,8 +16,12 @@ These are read by the container's startup scripts (`backend-functions`) and driv
 | `IPV6_SUBNET` | `fda9:4efe:7e3b:03ea::/64` | IPv6 ULA subnet to masquerade when `IPV6_NAT=1`. |
 | `VPN_GATEWAY` | _(unset)_ | Route the client subnet out through an upstream gateway container (e.g. a NordVPN container) instead of straight out the WAN. Set to the gateway's IP. Adds a fail-closed kill switch. See [[Gateway Mode]]. |
 | `VPN_GATEWAY6` | _(unset)_ | Upstream IPv6 gateway. Set to route the IPv6 client subnet through it; unset means forwarded client IPv6 is dropped. See [[Gateway Mode]]. |
-| `VPN_GATEWAY_TABLE` | `100` | Routing table used for the gateway default route. |
+| `VPN_GATEWAY_TABLE` | `100` | Routing table used for the gateway default route. Named gateways from `VPN_GATEWAYS` use the following tables (101, 102, …). |
 | `VPN_GATEWAY_RULE_PRIO` | `1000` | Priority of the `from <VPN_SUBNET>` policy rule. |
+| `VPN_GATEWAYS` | _(unset)_ | Named upstream gateways for per-user routing, e.g. `nl=172.28.0.2,us=172.28.0.4`. See [Gateway Mode#per-user-gateways](Gateway-Mode#per-user-gateways). |
+| `VPN_GATEWAYS6` | _(unset)_ | Optional IPv6 address per gateway name, e.g. `nl=fd00::2`. A gateway without one has its users' forwarded IPv6 dropped (fail-closed). |
+| `VPN_USER_GATEWAY` | _(unset)_ | Username → gateway name map, e.g. `user1=nl,user2=us`. Unmapped users follow `VPN_GATEWAY` or the default route; the reserved name `direct` bypasses `VPN_GATEWAY`. |
+| `VPN_GATEWAY_USER_RULE_PRIO` | `900` | Priority of the per-user policy rules; must be numerically lower (= stronger) than `VPN_GATEWAY_RULE_PRIO`. |
 
 > **About `PUID`/`PGID`:** this image does **not** implement LinuxServer-style `PUID`/`PGID` user remapping. Setting them has no effect; ocserv drops privileges internally via the `run-as-user`/`run-as-group` directives in `ocserv.conf`.
 

--- a/wiki/Gateway-Mode.md
+++ b/wiki/Gateway-Mode.md
@@ -15,7 +15,7 @@ Set `VPN_GATEWAY` to the upstream container's IP on the shared Docker network:
 
 | Variable | Default | Description |
 |---|---|---|
-| `VPN_GATEWAY` | _(unset)_ | Upstream gateway IP. Steers `VPN_SUBNET` to it and installs the kill switch. Unset = normal standalone ocserv. |
+| `VPN_GATEWAY` | _(unset)_ | Upstream gateway IP. Steers `VPN_SUBNET` to it and installs the kill switch. Unset or `direct` = normal standalone ocserv (clients exit via the ISP). |
 | `VPN_GATEWAY6` | _(unset)_ | Upstream IPv6 gateway. Set it to route the IPv6 client subnet too; unset = forwarded client IPv6 is dropped. |
 | `VPN_GATEWAY_TABLE` | `100` | Routing table used for the gateway default route. Named gateways use the following tables (101, 102, …). |
 | `VPN_GATEWAY_RULE_PRIO` | `1000` | Priority of the `from <VPN_SUBNET>` policy rule. |
@@ -78,6 +78,15 @@ environment:
   - VPN_GATEWAY=172.28.0.2                     # optional default for everyone else
 ```
 
+Or the other way around — everyone through the upstream VPN, but one user out the ISP directly:
+
+```yaml
+environment:
+  - VPN_SUBNET=10.20.0.0/24
+  - VPN_GATEWAY=172.28.0.2                     # everyone -> nordvpn
+  - VPN_USER_GATEWAY=alex=direct               # except alex -> ISP (default route)
+```
+
 ### How it works
 
 Routing is keyed on the client's **source IP**, and a user's IP is only known when their session comes up. So `init-vpngw` prepares one routing table and one kill-switch set per named gateway at boot, and installs `connect-script`/`disconnect-script` hooks into `ocserv.conf` (a managed, marked block — an existing script you configured is chain-called and restored if you disable the feature). On connect the hook looks the username up and adds a `/32` policy rule plus a kill-switch set entry for the session's address; on disconnect it removes them:
@@ -98,7 +107,7 @@ Each named gateway gets its own next-hop guard in the `inet ocserv_gw` nft table
 ### Details
 
 - **Unmapped users** follow `VPN_GATEWAY` if set, otherwise the container's default route — exactly the classic behavior.
-- **`direct`** is a reserved gateway name: a user mapped to it exits via the container's default route even when `VPN_GATEWAY` is set for everyone else.
+- **`direct`** is a reserved gateway name: a user mapped to it gets a per-session rule pointing at the **main** routing table, so they exit via the container's default route (the ISP) even when `VPN_GATEWAY` steers everyone else. Note there is deliberately no kill switch for a `direct` user — they behave like a standalone ocserv client. `VPN_GATEWAY=direct` is also accepted as an explicit way to say "unmapped users exit via the ISP" (same as leaving it unset).
 - **IPv6:** give a gateway an IPv6 address in `VPN_GATEWAYS6` and its users' IPv6 is policy-routed the same way. A gateway without one has its users' forwarded IPv6 **dropped**, so it can't bypass the IPv4 rule.
 - **Validation:** referencing an undefined gateway name in `VPN_USER_GATEWAY` fails container startup loudly.
 - Usernames containing `,` or `=` can't be expressed in the map.

--- a/wiki/Gateway-Mode.md
+++ b/wiki/Gateway-Mode.md
@@ -17,10 +17,14 @@ Set `VPN_GATEWAY` to the upstream container's IP on the shared Docker network:
 |---|---|---|
 | `VPN_GATEWAY` | _(unset)_ | Upstream gateway IP. Steers `VPN_SUBNET` to it and installs the kill switch. Unset = normal standalone ocserv. |
 | `VPN_GATEWAY6` | _(unset)_ | Upstream IPv6 gateway. Set it to route the IPv6 client subnet too; unset = forwarded client IPv6 is dropped. |
-| `VPN_GATEWAY_TABLE` | `100` | Routing table used for the gateway default route. |
+| `VPN_GATEWAY_TABLE` | `100` | Routing table used for the gateway default route. Named gateways use the following tables (101, 102, …). |
 | `VPN_GATEWAY_RULE_PRIO` | `1000` | Priority of the `from <VPN_SUBNET>` policy rule. |
+| `VPN_GATEWAYS` | _(unset)_ | Named gateways for [per-user routing](#per-user-gateways), e.g. `nl=172.28.0.2,us=172.28.0.4`. |
+| `VPN_GATEWAYS6` | _(unset)_ | Optional IPv6 address per gateway name, e.g. `nl=fd00::2`. |
+| `VPN_USER_GATEWAY` | _(unset)_ | Username → gateway name map, e.g. `user1=nl,user2=us`. |
+| `VPN_GATEWAY_USER_RULE_PRIO` | `900` | Priority of the per-user policy rules (wins over the subnet rule). |
 
-When `VPN_GATEWAY` is unset, the `init-vpngw` service is a no-op — ocserv behaves exactly as a standalone server (including normal IPv6).
+When `VPN_GATEWAY` and `VPN_GATEWAYS` are unset, the `init-vpngw` service is a no-op — ocserv behaves exactly as a standalone server (including normal IPv6).
 
 ## How it works
 
@@ -61,6 +65,43 @@ In every case clients lose internet rather than leaking out the host's real IP.
 
 - **Upstream is IPv4-only** (the NordVPN container is, by default): leave `VPN_GATEWAY6` unset. Forwarded client IPv6 is dropped so it can't bypass the IPv4 policy rule.
 - **Upstream is dual-stack**: set `VPN_GATEWAY6` to its IPv6 address. ocserv policy-routes `IPV6_SUBNET` to it with the same fail-closed next-hop guard. This also needs working IPv6 on the Docker network and the upstream forwarding IPv6 (see [Networking NAT and Routing#ipv6](Networking-NAT-and-Routing#ipv6)).
+
+## Per-user gateways
+
+Different users can exit through **different** upstream gateways — e.g. `user1` through a NordVPN-Netherlands container, `user2` through a NordVPN-US one, everyone else through `VPN_GATEWAY` (or straight out if it's unset):
+
+```yaml
+environment:
+  - VPN_SUBNET=10.20.0.0/24
+  - VPN_GATEWAYS=nl=172.28.0.2,us=172.28.0.4   # named gateways
+  - VPN_USER_GATEWAY=user1=nl,user2=us         # username -> gateway name
+  - VPN_GATEWAY=172.28.0.2                     # optional default for everyone else
+```
+
+### How it works
+
+Routing is keyed on the client's **source IP**, and a user's IP is only known when their session comes up. So `init-vpngw` prepares one routing table and one kill-switch set per named gateway at boot, and installs `connect-script`/`disconnect-script` hooks into `ocserv.conf` (a managed, marked block — an existing script you configured is chain-called and restored if you disable the feature). On connect the hook looks the username up and adds a `/32` policy rule plus a kill-switch set entry for the session's address; on disconnect it removes them:
+
+```
+$ ip rule                                # user1 and user2 online
+900:  from 10.20.0.37 lookup 101         # user1 -> nl
+900:  from 10.20.0.52 lookup 102         # user2 -> us
+1000: from 10.20.0.0/24 lookup 100       # everyone else -> VPN_GATEWAY
+```
+
+No static IP assignment is needed, dynamic pool addresses and multiple sessions per user work, and a stale address can never inherit a previous user's gateway (the hook scrubs the address before reuse).
+
+### Fail-closed, per user
+
+Each named gateway gets its own next-hop guard in the `inet ocserv_gw` nft table, driven by a per-gateway address set. A mapped user's traffic may leave the WAN **only** toward their own gateway — if the policy rule is missing it is dropped, never leaked out the host or another user's gateway. If the hook cannot install the rules on connect, the **session is rejected** rather than silently falling back to the default route.
+
+### Details
+
+- **Unmapped users** follow `VPN_GATEWAY` if set, otherwise the container's default route — exactly the classic behavior.
+- **`direct`** is a reserved gateway name: a user mapped to it exits via the container's default route even when `VPN_GATEWAY` is set for everyone else.
+- **IPv6:** give a gateway an IPv6 address in `VPN_GATEWAYS6` and its users' IPv6 is policy-routed the same way. A gateway without one has its users' forwarded IPv6 **dropped**, so it can't bypass the IPv4 rule.
+- **Validation:** referencing an undefined gateway name in `VPN_USER_GATEWAY` fails container startup loudly.
+- Usernames containing `,` or `=` can't be expressed in the map.
 
 ## Upstream requirements (NordVPN example)
 
@@ -122,6 +163,11 @@ docker exec ocserv-server nft list table inet ocserv_gw
 
 # a connected client's exit IP should equal the upstream's, not the host's
 docker exec ocserv-server sh -c 'curl -s https://1.1.1.1/cdn-cgi/trace | grep ^ip='
+
+# per-user gateways: parsed state and live per-session rules
+docker exec ocserv-server cat /run/ocserv-vpngw/gateways /run/ocserv-vpngw/users
+docker exec ocserv-server ip rule                        # one 900-prio rule per mapped session
+docker exec ocserv-server nft list table inet ocserv_gw  # session IPs inside the gw_<name>_v4 sets
 ```
 
 ---

--- a/wiki/Networking-NAT-and-Routing.md
+++ b/wiki/Networking-NAT-and-Routing.md
@@ -95,7 +95,7 @@ If that fails, leave IPv6 off.
 
 ## Routing clients through another VPN
 
-To send client traffic out through an upstream VPN container (e.g. NordVPN) instead of straight out the WAN, set `VPN_GATEWAY`. ocserv then policy-routes the client subnet to that gateway and adds a fail-closed kill switch. See **[[Gateway Mode]]**.
+To send client traffic out through an upstream VPN container (e.g. NordVPN) instead of straight out the WAN, set `VPN_GATEWAY`. ocserv then policy-routes the client subnet to that gateway and adds a fail-closed kill switch. Individual users can also be routed through different gateways with `VPN_GATEWAYS` + `VPN_USER_GATEWAY`. See **[[Gateway Mode]]**.
 
 ---
 


### PR DESCRIPTION
## Summary

Route different users through different upstream gateway containers (e.g. two NordVPN containers with different `COUNTRY`), configured entirely with env vars:

```yaml
environment:
  - VPN_GATEWAYS=nl=172.28.0.2,us=172.28.0.4   # named gateways
  - VPN_USER_GATEWAY=user1=nl,user2=us         # username -> gateway
  - VPN_GATEWAY=172.28.0.2                     # optional default for everyone else
```

## How it works

- **Boot (`init-vpngw`):** each named gateway gets its own routing table (`VPN_GATEWAY_TABLE`+1, +2, …) and a per-gateway kill-switch set in `inet ocserv_gw`. The parsed gateway/user maps are written to `/run/ocserv-vpngw/` for the hook. Unknown gateway names in `VPN_USER_GATEWAY` fail startup loudly.
- **Connect/disconnect hook (`ocserv-vpngw-script`):** routing is keyed on the client's source IP, which is only known when the session comes up, so ocserv's `connect-script` adds a `/32` policy rule (prio 900, beats the subnet rule at 1000) plus a kill-switch set entry for the assigned address; `disconnect-script` removes them. Works with the dynamic pool, any auth backend, and multiple sessions per user; stale addresses are scrubbed before reuse.
- **Fail-closed everywhere:** a mapped user's traffic may exit the WAN only toward their own gateway's next-hop; if the hook can't install the rules the session is **rejected** instead of falling back to the default route. IPv6 follows the gateway's `VPN_GATEWAYS6` address, or is dropped for gateways without one.
- **Config management:** the `connect-script`/`disconnect-script` directives are managed as a marked block in `ocserv.conf`; a pre-existing user script is commented out with a restore marker, chain-called by our hook, and restored when the feature is disabled. `init-vpngw` now depends on `init-config`.
- **Reserved name `direct`:** send a specific user out the container's default route even when `VPN_GATEWAY` is set for everyone else.
- **Backward compatible:** with only `VPN_GATEWAY` set, behavior is unchanged; with nothing set, `init-vpngw` stays a no-op.

## Testing

Verified with stubbed `ip`/`nft` harnesses:
- generated nft ruleset/table layout (per-gateway guards + accepts before the default subnet guard),
- config block injection idempotent across restarts, full restore on disable, original user script preserved and chained,
- hook scenarios: dual-stack gateway, v4-only gateway (client v6 → `v6_drop`), `direct`, unmapped user, disconnect cleanup, fail-closed rejection when rule install fails,
- unknown gateway name → startup exit 1.

## Docs

README env table + gateway section, wiki **Gateway Mode** (new *Per-user gateways* section incl. verify commands), **Configuration Reference**, **Networking NAT and Routing**.