### PR TITLE
📋 Bump s6-overlay to v3.2.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ ARG TARGETARCH
 ARG TARGETVARIANT
 
 ARG PACKAGE="just-containers/s6-overlay"
-ARG PACKAGEVERSION="3.2.3.0"
+ARG PACKAGEVERSION="3.2.3.1"
 
 RUN echo "**** install security fix packages ****" && \
     echo "**** install mandatory packages ****" && \


### PR DESCRIPTION
## 📋 Package Version Update

**Repository**: [just-containers/s6-overlay](https://github.com/just-containers/s6-overlay)
**Version**: `3.2.3.1`

This PR updates the package version in the Dockerfile.

### Changes:
- Updated `PACKAGEVERSION` environment variable in Dockerfile
- Updated version reference in README.md
- Bumped from previous version to `3.2.3.1`

---
🤖 Auto-generated by [update-packages workflow](https://github.com/azinchen/ocserv-server/actions/workflows/maintenance-updates.yml)