### PR TITLE
feat: multi-network support — WAN auto-detect and per-gateway egress NAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You provide an `ocserv.conf` and a certificate in the config volume. Ready-to-us
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `VPN_SUBNET` | `10.10.10.0/24` | VPN client subnet (must match `ipv4-network` in `ocserv.conf`) |
-| `WAN_IF` | `eth0` | WAN interface for NAT |
+| `WAN_IF` | _(auto)_ | WAN interface for NAT. Auto-detected from the container's default route (falls back to `eth0`); set explicitly to override |
 | `IPV6_NAT` | `0` | enable IPv6 masquerade (see the IPv6 notes on the wiki) |
 | `VPN_GATEWAY` | _(unset)_ | Route the client subnet out through an upstream gateway container (e.g. a NordVPN container with `FORWARD_FROM`) via source-based policy routing. Set to the gateway's IP. Adds a fail-closed nft kill switch (`inet ocserv_gw`) so client traffic can only leave toward the gateway. |
 | `VPN_GATEWAY6` | _(unset)_ | IPv6 gateway for gateway mode. If set, the IPv6 client subnet is policy-routed to it; if unset, forwarded client IPv6 is **dropped** to prevent leaks. |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You provide an `ocserv.conf` and a certificate in the config volume. Ready-to-us
 | `VPN_SUBNET` | `10.10.10.0/24` | VPN client subnet (must match `ipv4-network` in `ocserv.conf`) |
 | `WAN_IF` | _(auto)_ | WAN interface for NAT. Auto-detected from the container's default route (falls back to `eth0`); set explicitly to override |
 | `IPV6_NAT` | `0` | enable IPv6 masquerade (see the IPv6 notes on the wiki) |
-| `VPN_GATEWAY` | _(unset)_ | Route the client subnet out through an upstream gateway container (e.g. a NordVPN container with `FORWARD_FROM`) via source-based policy routing. Set to the gateway's IP. Adds a fail-closed nft kill switch (`inet ocserv_gw`) so client traffic can only leave toward the gateway. |
+| `VPN_GATEWAY` | _(unset)_ | Route the client subnet out through an upstream gateway container (e.g. a NordVPN container with `FORWARD_FROM`) via source-based policy routing. Set to the gateway's IP. Adds a fail-closed nft kill switch (`inet ocserv_gw`) so client traffic can only leave toward the gateway. The gateway may sit on a different interface than `WAN_IF` (multi-network setups); its egress interface gets its own masquerade rule automatically. |
 | `VPN_GATEWAY6` | _(unset)_ | IPv6 gateway for gateway mode. If set, the IPv6 client subnet is policy-routed to it; if unset, forwarded client IPv6 is **dropped** to prevent leaks. |
 | `VPN_GATEWAY_TABLE` | `100` | Routing table used for gateway mode. |
 | `VPN_GATEWAY_RULE_PRIO` | `1000` | Priority of the `from <VPN_SUBNET>` policy rule. |

--- a/rootfs/etc/s6-overlay/s6-rc.d/init-nat/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/init-nat/run
@@ -46,6 +46,67 @@ if [ "$ipv6_nat" = "1" ]; then
         ip6 saddr $ipv6_subnet oifname \"$wan_if\" masquerade"
 fi
 
+# Gateway egress interfaces: an upstream gateway (VPN_GATEWAY / VPN_GATEWAYS)
+# may sit on a different interface than the WAN - e.g. a bridge to a VPN
+# sidecar container while the WAN is a macvlan ISP uplink. Masquerade and
+# forward via each such interface too, so the upstream sees this container's
+# address and needs no return route to the client subnet.
+gw_dev() { # print the egress interface for a gateway IP ($1 = -4|-6, $2 = IP)
+    ip "$1" route get "$2" 2>/dev/null \
+        | awk '{for (i = 1; i < NF; i++) if ($i == "dev") {print $(i + 1); exit}}'
+}
+
+gw_ifs4=""
+for gw in $vpn_gateway $(kv_pairs "$vpn_gateways" | awk '{print $2}'); do
+    dev="$(gw_dev -4 "$gw")"
+    if [ -z "$dev" ]; then
+        log_error "[INIT-NAT] Warning: cannot resolve egress interface for gateway $gw"
+    elif [ "$dev" != "$wan_if" ]; then
+        case " $gw_ifs4 " in
+            *" $dev "*) ;;
+            *) gw_ifs4="$gw_ifs4 $dev" ;;
+        esac
+    fi
+done
+
+gw_ifs6=""
+for gw in $vpn_gateway6 $(kv_pairs "$vpn_gateways6" | awk '{print $2}'); do
+    dev="$(gw_dev -6 "$gw")"
+    if [ -z "$dev" ]; then
+        log_error "[INIT-NAT] Warning: cannot resolve egress interface for gateway $gw"
+    elif [ "$dev" != "$wan_if" ]; then
+        case " $gw_ifs6 " in
+            *" $dev "*) ;;
+            *) gw_ifs6="$gw_ifs6 $dev" ;;
+        esac
+    fi
+done
+
+for dev in $gw_ifs4; do
+    log "[INIT-NAT] Gateway egress via $dev: masquerading $vpn_subnet"
+    nat_rules="$nat_rules
+        ip saddr $vpn_subnet oifname \"$dev\" masquerade"
+done
+if [ "$ipv6_nat" = "1" ]; then
+    for dev in $gw_ifs6; do
+        log "[INIT-NAT] Gateway egress via $dev: masquerading $ipv6_subnet"
+        nat_rules="$nat_rules
+        ip6 saddr $ipv6_subnet oifname \"$dev\" masquerade"
+    done
+fi
+
+gw_fwd_rules=""
+gw_fwd_seen=""
+for dev in $gw_ifs4 $gw_ifs6; do
+    case " $gw_fwd_seen " in
+        *" $dev "*) continue ;;
+    esac
+    gw_fwd_seen="$gw_fwd_seen $dev"
+    gw_fwd_rules="$gw_fwd_rules
+        iifname \"$vpn_ifname\" oifname \"$dev\" accept
+        iifname \"$dev\" oifname \"$vpn_ifname\" ct state related,established accept"
+done
+
 # Apply the ruleset in a dedicated table. Deleting it first keeps this idempotent
 # across service restarts. Forwarding rules in the inet family cover IPv4 and IPv6.
 log "[INIT-NAT] Setting up forwarding rules"
@@ -55,7 +116,7 @@ table inet ocserv {
     chain forward {
         type filter hook forward priority 0; policy accept;
         iifname "$vpn_ifname" oifname "$wan_if" accept
-        iifname "$wan_if" oifname "$vpn_ifname" ct state related,established accept
+        iifname "$wan_if" oifname "$vpn_ifname" ct state related,established accept$gw_fwd_rules
     }
     chain postrouting {
         type nat hook postrouting priority 100; policy accept;

--- a/rootfs/etc/s6-overlay/s6-rc.d/init-vpngw/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/init-vpngw/run
@@ -27,11 +27,6 @@ set -eu
 
 conf=/etc/ocserv/ocserv.conf
 
-# VPN_GATEWAY=direct is an explicit alias for "no default gateway": unmapped
-# users exit via the container's default route (the ISP)
-[ "$vpn_gateway" = "direct" ] && vpn_gateway=""
-[ "$vpn_gateway6" = "direct" ] && vpn_gateway6=""
-
 # Undo our managed edits in ocserv.conf (managed block + commented-out user
 # hooks). Only touches the file if our markers are present.
 restore_config() {

--- a/rootfs/usr/local/bin/backend-functions
+++ b/rootfs/usr/local/bin/backend-functions
@@ -4,7 +4,17 @@
 setcap_net_bind="${SETCAP_NET_BIND:-1}"
 setcap_net_admin="${SETCAP_NET_ADMIN:-1}"
 vpn_subnet="${VPN_SUBNET:-10.10.10.0/24}"
-wan_if="${WAN_IF:-eth0}"
+wan_if="${WAN_IF:-}"
+if [ -z "$wan_if" ]; then
+    # Auto-detect the WAN interface from the IPv4 default route. In a plain
+    # bridge network that is eth0, but with extra networks attached (e.g. a
+    # macvlan for the ISP uplink) the ISP-facing interface may be eth1 or
+    # later - Docker attaches networks in lexicographic order, so the name is
+    # not stable. The default route always points out the "outside".
+    wan_if="$(ip -4 route show default 2>/dev/null \
+        | awk '{for (i = 1; i < NF; i++) if ($i == "dev") {print $(i + 1); exit}}')"
+    wan_if="${wan_if:-eth0}"
+fi
 vpn_if="${VPN_IF:-vpns+}"
 vpn_gateway="${VPN_GATEWAY:-}"
 vpn_gateway6="${VPN_GATEWAY6:-}"

--- a/rootfs/usr/local/bin/backend-functions
+++ b/rootfs/usr/local/bin/backend-functions
@@ -25,6 +25,11 @@ vpn_gateways6="${VPN_GATEWAYS6:-}"
 vpn_user_gateway="${VPN_USER_GATEWAY:-}"
 vpn_gateway_user_rule_prio="${VPN_GATEWAY_USER_RULE_PRIO:-900}"
 
+# VPN_GATEWAY=direct is an explicit alias for "no default gateway": unmapped
+# users exit via the container's default route (the ISP)
+[ "$vpn_gateway" = "direct" ] && vpn_gateway=""
+[ "$vpn_gateway6" = "direct" ] && vpn_gateway6=""
+
 # Runtime state shared between init-vpngw and the ocserv connect/disconnect hook
 vpngw_state_dir="/run/ocserv-vpngw"
 ipv6_forward="${IPV6_FORWARD:-1}"

--- a/wiki/Configuration-Reference.md
+++ b/wiki/Configuration-Reference.md
@@ -9,7 +9,7 @@ These are read by the container's startup scripts (`backend-functions`) and driv
 | Variable | Default | Description |
 |---|---|---|
 | `VPN_SUBNET` | `10.10.10.0/24` | IPv4 subnet that gets source-NAT (masquerade) out of the WAN interface. **Must match the `ipv4-network`/`ipv4-netmask` in your `ocserv.conf`.** |
-| `WAN_IF` | `eth0` | The container interface used as the NAT egress (the "outside"). |
+| `WAN_IF` | _(auto)_ | The container interface used as the NAT egress (the "outside"). By default it is auto-detected from the container's IPv4 default route, which handles multi-network setups (e.g. a macvlan ISP uplink on `eth1`); falls back to `eth0` if there is no default route. Set explicitly to override. |
 | `VPN_IF` | `vpns+` | Interface pattern for the tun devices ocserv creates. The trailing `+` is translated to the nftables wildcard `vpns*`. Matches `device = vpns` in `ocserv.conf`. |
 | `IPV6_FORWARD` | `1` | Enable IPv6 forwarding sysctl inside the container. |
 | `IPV6_NAT` | `0` | Enable IPv6 masquerade for `IPV6_SUBNET`. Off by default — see the IPv6 warning below. |

--- a/wiki/Gateway-Mode.md
+++ b/wiki/Gateway-Mode.md
@@ -29,7 +29,7 @@ When `VPN_GATEWAY` and `VPN_GATEWAYS` are unset, the `init-vpngw` service is a n
 ## How it works
 
 1. **Source-based policy routing** — `init-vpngw` adds `ip rule from <VPN_SUBNET> lookup <table>` and a default route in that table via `VPN_GATEWAY`. Only client-sourced packets follow it; ocserv's own traffic and the inbound listener keep the main default route.
-2. **Masquerade** — `init-nat` already SNATs clients to the container's own address, so the upstream sees a Docker-subnet source and needs **no return route** to your client subnet.
+2. **Masquerade** — `init-nat` already SNATs clients to the container's own address, so the upstream sees a Docker-subnet source and needs **no return route** to your client subnet. This also works when the gateway sits on a **different interface** than the WAN (e.g. a bridge to the sidecar plus a macvlan ISP uplink): `init-nat` resolves each gateway's egress interface from the routing table and installs a masquerade rule for it too.
 3. **Kill switch** — a dedicated nft table (`inet ocserv_gw`) drops any client packet that would egress the WAN by a next-hop other than the gateway. See below.
 
 ### Why not just set a default gateway?

--- a/wiki/Networking-NAT-and-Routing.md
+++ b/wiki/Networking-NAT-and-Routing.md
@@ -35,6 +35,7 @@ table inet ocserv {
 - The masqueraded subnet comes from **`VPN_SUBNET`**.
 - The egress interface comes from **`WAN_IF`** (auto-detected from the default route when unset).
 - The tunnel interface pattern comes from **`VPN_IF`** (`vpns+` → `vpns*`).
+- If an upstream gateway (`VPN_GATEWAY` / `VPN_GATEWAYS`) sits on a different interface than the WAN (multi-network setups, e.g. a macvlan ISP uplink plus a bridge to a VPN sidecar), that gateway's egress interface gets its own masquerade and forward rules automatically.
 
 Inspect it live:
 

--- a/wiki/Networking-NAT-and-Routing.md
+++ b/wiki/Networking-NAT-and-Routing.md
@@ -33,7 +33,7 @@ table inet ocserv {
 ```
 
 - The masqueraded subnet comes from **`VPN_SUBNET`**.
-- The egress interface comes from **`WAN_IF`**.
+- The egress interface comes from **`WAN_IF`** (auto-detected from the default route when unset).
 - The tunnel interface pattern comes from **`VPN_IF`** (`vpns+` → `vpns*`).
 
 Inspect it live:


### PR DESCRIPTION
## Summary

Support macvlan (and other multi-network) environments out of the box. When a container has extra networks attached — e.g. a macvlan ISP uplink plus a bridge to a VPN sidecar — the ISP-facing interface may be `eth1` or later (Docker attaches networks in lexicographic order), and direct-user and gateway-user traffic legitimately egress *different* interfaces. The previous single hardcoded `eth0` covered neither reliably.

## Changes

**1. WAN interface auto-detection** (`backend-functions`)
- When `WAN_IF` is unset, detect the WAN interface from the container's IPv4 default route (`ip -4 route show default`); fall back to `eth0` when no default route exists. `WAN_IF` remains an explicit override.
- All consumers (`init-nat`, `init-vpngw` kill-switch) pick it up automatically.

**2. Per-gateway egress NAT** (`init-nat`)
- Each gateway from `VPN_GATEWAY` / `VPN_GATEWAYS` (and their IPv6 counterparts) has its egress interface resolved via `ip route get`; every distinct interface beyond `WAN_IF` gets its own masquerade + forward rules in `inet ocserv`.
- Eliminates the need for a supplemental SNAT sidecar in split-interface deployments: the upstream sees this container's bridge address and needs no return route to the client subnet (also satisfies sidecar `FORWARD_FROM` subnet filters).
- IPv6 gateway interfaces are masqueraded only when `IPV6_NAT=1`, matching WAN behavior. Unresolvable gateways log a warning and are skipped.
- `VPN_GATEWAY=direct` alias normalization moved from `init-vpngw` into `backend-functions` so `init-nat` sees clean values.

**3. Docs** — README, Configuration Reference, Networking, and Gateway Mode wiki pages.

## Testing

Ran `init-nat` end-to-end with stubbed `ip`/`nft` against four topologies:
- **Split-interface (macvlan + bridge sidecar)**: produces masquerade + forward rules for both `eth1` (WAN, auto-detected) and `eth0` (gateway egress).
- **Classic single-bridge**: byte-identical ruleset to the previous release.
- **Named gateways**: multiple gateways on one interface dedupe to a single rule set; an unresolvable gateway warns and is skipped; `VPN_GATEWAY=direct` adds nothing.
- **`IPV6_NAT=1` with `VPN_GATEWAY6`**: v6 masquerade emitted for the gateway interface; gated off otherwise.

Verified busybox `ip route get` output parsing against the live container on edge-svc. shellcheck clean (no new findings).

## Backward compatibility

Single-network deployments: default route is on `eth0`, gateways share that interface → detection yields `eth0` and no extra rules; the generated ruleset is byte-identical. Explicit `WAN_IF` settings behave exactly as before.