### PR TITLE
feat: forward extra LAN subnets through gateway mode (FORWARD_SUBNETS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ You provide an `ocserv.conf` and a certificate in the config volume. Ready-to-us
 | `VPN_GATEWAYS` | _(unset)_ | Named upstream gateways for per-user routing, e.g. `nl=172.28.0.2,us=172.28.0.4`. Each gets its own routing table and kill-switch set. |
 | `VPN_GATEWAYS6` | _(unset)_ | Optional IPv6 address per gateway name, e.g. `nl=fd00::2`. A name without one has its users' forwarded IPv6 dropped (fail-closed). |
 | `VPN_USER_GATEWAY` | _(unset)_ | Username → gateway name map, e.g. `user1=nl,user2=us`. Unmapped users follow `VPN_GATEWAY` (or the default route if unset); the reserved name `direct` sends a user out the container's default route (the ISP) even when `VPN_GATEWAY` is set. `VPN_GATEWAY=direct` is accepted as an explicit "no default gateway". |
+| `FORWARD_SUBNETS` | _(unset)_ | Extra source subnets (e.g. a LAN routing through this container as its gateway) that get the same treatment as the client subnet: policy route to a gateway, masquerade, and a fail-closed guard. Entries: `subnet` (follows `VPN_GATEWAY`), `subnet=name` (named `VPN_GATEWAYS` gateway), `subnet=direct` (ISP egress). E.g. `192.168.50.0/24=nl,192.168.60.0/24=direct`. |
+| `FORWARD_SUBNETS6` | _(unset)_ | Same for IPv6 source subnets, mapping to `VPN_GATEWAY6` / `VPN_GATEWAYS6`. A named gateway without an IPv6 address is a config error. Masqueraded only when `IPV6_NAT=1`. |
 | `VPN_GATEWAY_USER_RULE_PRIO` | `900` | Priority of the per-user policy rules (must be lower than `VPN_GATEWAY_RULE_PRIO` to win). |
 
 Full reference: [Configuration Reference](https://github.com/azinchen/ocserv-server/wiki/Configuration-Reference).

--- a/rootfs/etc/s6-overlay/s6-rc.d/init-nat/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/init-nat/run
@@ -35,17 +35,6 @@ case "$vpn_if" in
     *)  vpn_ifname="$vpn_if" ;;
 esac
 
-# IPv4 NAT
-log "[INIT-NAT] Setting up IPv4 NAT for subnet $vpn_subnet via $wan_if"
-nat_rules="ip saddr $vpn_subnet oifname \"$wan_if\" masquerade"
-
-# IPv6 NAT (optional)
-if [ "$ipv6_nat" = "1" ]; then
-    log "[INIT-NAT] Setting up IPv6 NAT for subnet $ipv6_subnet via $wan_if"
-    nat_rules="$nat_rules
-        ip6 saddr $ipv6_subnet oifname \"$wan_if\" masquerade"
-fi
-
 # Gateway egress interfaces: an upstream gateway (VPN_GATEWAY / VPN_GATEWAYS)
 # may sit on a different interface than the WAN - e.g. a bridge to a VPN
 # sidecar container while the WAN is a macvlan ISP uplink. Masquerade and
@@ -82,16 +71,34 @@ for gw in $vpn_gateway6 $(kv_pairs "$vpn_gateways6" | awk '{print $2}'); do
     fi
 done
 
-for dev in $gw_ifs4; do
-    log "[INIT-NAT] Gateway egress via $dev: masquerading $vpn_subnet"
-    nat_rules="$nat_rules
-        ip saddr $vpn_subnet oifname \"$dev\" masquerade"
+# Masqueraded source subnets: the VPN client subnet plus any forwarded LAN
+# subnets (FORWARD_SUBNETS / FORWARD_SUBNETS6) that use this container as
+# their gateway. Each subnet is masqueraded via the WAN and via every
+# gateway egress interface.
+masq_subnets4="$vpn_subnet"
+for s in $(fwd_subnet_pairs "$forward_subnets" | awk '{print $1}'); do
+    masq_subnets4="$masq_subnets4 $s"
+done
+masq_subnets6="$ipv6_subnet"
+for s in $(fwd_subnet_pairs "$forward_subnets6" | awk '{print $1}'); do
+    masq_subnets6="$masq_subnets6 $s"
+done
+
+nat_rules=""
+for dev in $wan_if $gw_ifs4; do
+    for s in $masq_subnets4; do
+        log "[INIT-NAT] Masquerading $s via $dev"
+        nat_rules="$nat_rules
+        ip saddr $s oifname \"$dev\" masquerade"
+    done
 done
 if [ "$ipv6_nat" = "1" ]; then
-    for dev in $gw_ifs6; do
-        log "[INIT-NAT] Gateway egress via $dev: masquerading $ipv6_subnet"
-        nat_rules="$nat_rules
-        ip6 saddr $ipv6_subnet oifname \"$dev\" masquerade"
+    for dev in $wan_if $gw_ifs6; do
+        for s in $masq_subnets6; do
+            log "[INIT-NAT] Masquerading $s via $dev (IPv6)"
+            nat_rules="$nat_rules
+        ip6 saddr $s oifname \"$dev\" masquerade"
+        done
     done
 fi
 
@@ -119,8 +126,7 @@ table inet ocserv {
         iifname "$wan_if" oifname "$vpn_ifname" ct state related,established accept$gw_fwd_rules
     }
     chain postrouting {
-        type nat hook postrouting priority 100; policy accept;
-        $nat_rules
+        type nat hook postrouting priority 100; policy accept;$nat_rules
     }
 }
 EOF

--- a/rootfs/etc/s6-overlay/s6-rc.d/init-vpngw/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/init-vpngw/run
@@ -96,6 +96,76 @@ if [ -n "$vpn_user_gateway" ]; then
     rm -f "$vpngw_state_dir/users.tmp"
 fi
 
+# ---- Forwarded LAN subnets -------------------------------------------------
+# FORWARD_SUBNETS / FORWARD_SUBNETS6 give extra source subnets (e.g. a LAN
+# routing through this container as its gateway) the same treatment as the
+# client subnet: a policy route to a gateway, masquerade (done by init-nat)
+# and a fail-closed next-hop guard in the kill switch. Entry forms:
+#   subnet          - follows VPN_GATEWAY / VPN_GATEWAY6 (direct when unset)
+#   subnet=name     - routes via a named VPN_GATEWAYS gateway
+#   subnet=direct   - explicit main-table (ISP) egress
+fwd_guard_rules=""
+add_fwd_subnet() { # $1 = -4|-6, $2 = subnet, $3 = gateway name ("-" = default)
+    fam="$1" subnet="$2" gwname="$3"
+    case "$gwname" in
+        -)
+            if [ "$fam" = "-4" ]; then gw="$vpn_gateway"; else gw="$vpn_gateway6"; fi
+            if [ -z "$gw" ]; then
+                log "[INIT-VPNGW] Forwarded subnet $subnet exits via the default route"
+                return 0
+            fi
+            gw_table="$table"
+            ;;
+        direct)
+            log "[INIT-VPNGW] Forwarded subnet $subnet exits via the default route"
+            return 0
+            ;;
+        *)
+            # shellcheck disable=SC2046
+            set -- $(awk -v n="$gwname" '$1 == n { print $2, $3, $4 }' \
+                "$vpngw_state_dir/gateways" 2>/dev/null)
+            if [ $# -lt 3 ]; then
+                log_error "[INIT-VPNGW] FORWARD_SUBNETS: unknown gateway '$gwname' for subnet $subnet (define it in VPN_GATEWAYS)"
+                exit 1
+            fi
+            gw_table="$1"
+            if [ "$fam" = "-4" ]; then gw="$2"; else gw="$3"; fi
+            if [ "$gw" = "-" ]; then
+                log_error "[INIT-VPNGW] FORWARD_SUBNETS6: gateway '$gwname' has no IPv6 address for subnet $subnet (set it in VPN_GATEWAYS6)"
+                exit 1
+            fi
+            ;;
+    esac
+    log "[INIT-VPNGW] Forwarded subnet $subnet routes via $gw (table $gw_table)"
+    if [ "$fam" = "-4" ]; then
+        ip rule show | grep -q "from $subnet lookup $gw_table" \
+            || ip rule add from "$subnet" lookup "$gw_table" priority "$prio"
+        fwd_guard_rules="$fwd_guard_rules
+        ip saddr $subnet oifname \"$wan_if\" rt ip nexthop != $gw drop"
+    else
+        ip -6 rule show 2>/dev/null | grep -q "from $subnet lookup $gw_table" \
+            || ip -6 rule add from "$subnet" lookup "$gw_table" priority "$prio" \
+            || log_error "[INIT-VPNGW] Warning: could not add IPv6 policy rule for $subnet"
+        fwd_guard_rules="$fwd_guard_rules
+        ip6 saddr $subnet oifname \"$wan_if\" rt ip6 nexthop != $gw drop"
+    fi
+}
+
+if [ -n "$forward_subnets" ]; then
+    fwd_subnet_pairs "$forward_subnets" > "$vpngw_state_dir/fwd4.tmp"
+    while read -r subnet gwname; do
+        add_fwd_subnet -4 "$subnet" "$gwname"
+    done < "$vpngw_state_dir/fwd4.tmp"
+    rm -f "$vpngw_state_dir/fwd4.tmp"
+fi
+if [ -n "$forward_subnets6" ]; then
+    fwd_subnet_pairs "$forward_subnets6" > "$vpngw_state_dir/fwd6.tmp"
+    while read -r subnet gwname; do
+        add_fwd_subnet -6 "$subnet" "$gwname"
+    done < "$vpngw_state_dir/fwd6.tmp"
+    rm -f "$vpngw_state_dir/fwd6.tmp"
+fi
+
 # ---- Default gateway: IPv4 routing -----------------------------------------
 if [ -n "$vpn_gateway" ]; then
     log "[INIT-VPNGW] Routing $vpn_subnet via $vpn_gateway (table $table)"
@@ -175,7 +245,7 @@ nft delete table inet ocserv_gw 2>/dev/null || true
 if nft -f - <<EOF
 table inet ocserv_gw {$nft_sets
     chain forward {
-        type filter hook forward priority -10; policy accept;$user_rules
+        type filter hook forward priority -10; policy accept;$user_rules$fwd_guard_rules
         $default_rules
     }
 }

--- a/rootfs/usr/local/bin/backend-functions
+++ b/rootfs/usr/local/bin/backend-functions
@@ -24,6 +24,8 @@ vpn_gateways="${VPN_GATEWAYS:-}"
 vpn_gateways6="${VPN_GATEWAYS6:-}"
 vpn_user_gateway="${VPN_USER_GATEWAY:-}"
 vpn_gateway_user_rule_prio="${VPN_GATEWAY_USER_RULE_PRIO:-900}"
+forward_subnets="${FORWARD_SUBNETS:-}"
+forward_subnets6="${FORWARD_SUBNETS6:-}"
 
 # VPN_GATEWAY=direct is an explicit alias for "no default gateway": unmapped
 # users exit via the container's default route (the ISP)
@@ -55,4 +57,12 @@ kv_pairs() {
 # Print the value for a key in a "key=value,key=value" list (empty if absent)
 kv_get() {
     kv_pairs "${1:-}" | awk -v k="$2" '$1 == k { print $2; exit }'
+}
+
+# Print "subnet gateway" lines from a "subnet[=gateway],subnet[=gateway]" list
+# (gateway is "-" when the entry has no =gateway part)
+fwd_subnet_pairs() {
+    [ -n "${1:-}" ] || return 0
+    echo "$1" | tr ',' '\n' | \
+        awk -F= '{ gsub(/[[:space:]]/, "") } $1 != "" { print $1 " " ($2 != "" ? $2 : "-") }'
 }

--- a/wiki/Configuration-Reference.md
+++ b/wiki/Configuration-Reference.md
@@ -21,6 +21,8 @@ These are read by the container's startup scripts (`backend-functions`) and driv
 | `VPN_GATEWAYS` | _(unset)_ | Named upstream gateways for per-user routing, e.g. `nl=172.28.0.2,us=172.28.0.4`. See [Gateway Mode#per-user-gateways](Gateway-Mode#per-user-gateways). |
 | `VPN_GATEWAYS6` | _(unset)_ | Optional IPv6 address per gateway name, e.g. `nl=fd00::2`. A gateway without one has its users' forwarded IPv6 dropped (fail-closed). |
 | `VPN_USER_GATEWAY` | _(unset)_ | Username → gateway name map, e.g. `user1=nl,user2=us`. Unmapped users follow `VPN_GATEWAY` or the default route; the reserved name `direct` sends a user out the container's default route (the ISP) even when `VPN_GATEWAY` is set. |
+| `FORWARD_SUBNETS` | _(unset)_ | Extra IPv4 source subnets that route through this container as their gateway (e.g. a LAN pointing a static route at it). Each entry is `subnet`, `subnet=name`, or `subnet=direct` — same semantics as user mappings, applied to whole subnets. See [Gateway Mode#forwarded-lan-subnets](Gateway-Mode#forwarded-lan-subnets). |
+| `FORWARD_SUBNETS6` | _(unset)_ | Same for IPv6 source subnets, mapping to `VPN_GATEWAY6` / `VPN_GATEWAYS6`. A named gateway without an IPv6 address is rejected at startup. Masqueraded only when `IPV6_NAT=1`. |
 | `VPN_GATEWAY_USER_RULE_PRIO` | `900` | Priority of the per-user policy rules; must be numerically lower (= stronger) than `VPN_GATEWAY_RULE_PRIO`. |
 
 > **About `PUID`/`PGID`:** this image does **not** implement LinuxServer-style `PUID`/`PGID` user remapping. Setting them has no effect; ocserv drops privileges internally via the `run-as-user`/`run-as-group` directives in `ocserv.conf`.

--- a/wiki/Gateway-Mode.md
+++ b/wiki/Gateway-Mode.md
@@ -112,6 +112,34 @@ Each named gateway gets its own next-hop guard in the `inet ocserv_gw` nft table
 - **Validation:** referencing an undefined gateway name in `VPN_USER_GATEWAY` fails container startup loudly.
 - Usernames containing `,` or `=` can't be expressed in the map.
 
+## Forwarded LAN subnets
+
+Devices on your LAN can use the ocserv container as their **next-hop gateway** (a static route on the LAN router pointing a subnet at the container's address) and get the same egress treatment as VPN clients — without an ocserv session. List those source subnets in `FORWARD_SUBNETS`:
+
+```yaml
+environment:
+  - VPN_GATEWAYS=nl=172.28.0.2
+  - FORWARD_SUBNETS=192.168.50.0/24=nl,192.168.60.0/24=direct,10.30.0.0/24
+```
+
+Entry forms, mirroring the per-user map:
+
+| Form | Egress |
+|---|---|
+| `subnet` | follows `VPN_GATEWAY` (the default route if unset) |
+| `subnet=name` | the named `VPN_GATEWAYS` gateway |
+| `subnet=direct` | the container's default route (the ISP) |
+
+Each subnet gets:
+
+1. **Policy route** — `ip rule from <subnet>` into the mapped gateway's routing table (installed at startup; unlike per-user rules, no connect hook is needed since the subnet is static).
+2. **Masquerade** — `init-nat` SNATs the subnet out the WAN and every gateway egress interface, so neither the upstream nor the ISP needs a return route to it.
+3. **Kill switch** — a next-hop guard in `inet ocserv_gw`: the subnet's traffic may leave the WAN only toward its mapped gateway, otherwise it is dropped.
+
+IPv6 source subnets go in `FORWARD_SUBNETS6` with the same forms, mapped against `VPN_GATEWAY6` / `VPN_GATEWAYS6`; naming a gateway that has no IPv6 address fails startup loudly. IPv6 masquerade requires `IPV6_NAT=1`.
+
+> Referencing an undefined gateway name fails container startup, same as `VPN_USER_GATEWAY`. Remember the LAN router needs a static route for the *return* direction only if you skip masquerade — with `FORWARD_SUBNETS` the masquerade makes return routing automatic.
+
 ## Upstream requirements (NordVPN example)
 
 The upstream must forward the Docker subnet out its tunnel. The companion [NordVPN image](https://github.com/azinchen/nordvpn) does this with `FORWARD_FROM`:

--- a/wiki/Networking-NAT-and-Routing.md
+++ b/wiki/Networking-NAT-and-Routing.md
@@ -36,6 +36,7 @@ table inet ocserv {
 - The egress interface comes from **`WAN_IF`** (auto-detected from the default route when unset).
 - The tunnel interface pattern comes from **`VPN_IF`** (`vpns+` → `vpns*`).
 - If an upstream gateway (`VPN_GATEWAY` / `VPN_GATEWAYS`) sits on a different interface than the WAN (multi-network setups, e.g. a macvlan ISP uplink plus a bridge to a VPN sidecar), that gateway's egress interface gets its own masquerade and forward rules automatically.
+- Extra source subnets listed in `FORWARD_SUBNETS` / `FORWARD_SUBNETS6` (LANs routing through the container as their gateway) are masqueraded the same way as the client subnet — see [Gateway Mode#forwarded-lan-subnets](Gateway-Mode#forwarded-lan-subnets).
 
 Inspect it live:
 


### PR DESCRIPTION
## Summary

LAN devices can use the ocserv container as their next-hop gateway (static route on the LAN router), but until now only `VPN_SUBNET` sources were policy-routed, masqueraded, and covered by the kill switch — forwarded LAN traffic fell through to the default route (the ISP) with its original source address, bypassing gateway mode entirely.

`FORWARD_SUBNETS` / `FORWARD_SUBNETS6` list extra source subnets that get the same treatment as the client subnet, mirroring the `VPN_USER_GATEWAY` semantics at subnet granularity:

| Entry | Egress |
|---|---|
| `subnet` | follows `VPN_GATEWAY` / `VPN_GATEWAY6` (default route when unset) |
| `subnet=name` | named `VPN_GATEWAYS` gateway |
| `subnet=direct` | explicit main-table (ISP) egress |

Example: `FORWARD_SUBNETS=192.168.50.0/24=nl,192.168.60.0/24=direct`

## Changes

- **`init-vpngw`**: installs `ip rule from <subnet>` into the mapped gateway's table at startup (no connect hook needed — subnets are static), plus a fail-closed next-hop guard per subnet in `inet ocserv_gw`. Unknown gateway names and IPv6 subnets mapped to a v4-only gateway fail startup loudly.
- **`init-nat`**: masquerades every listed subnet out the WAN and each gateway egress interface (composes with the per-gateway egress NAT from #97). IPv6 subnets are masqueraded only when `IPV6_NAT=1`.
- **`backend-functions`**: new `fwd_subnet_pairs` parser for `subnet[=gateway]` lists.
- **Docs**: README + Configuration Reference rows, new "Forwarded LAN subnets" section in the Gateway Mode wiki page, Networking page bullet.

## Testing

Ran both init scripts end-to-end with stubbed `ip`/`nft`:
- Bare subnet + `VPN_GATEWAY`: policy rule into table 100 + next-hop guard alongside the client subnet's.
- `subnet=name` + `subnet=direct` with `VPN_GATEWAYS`: rule into the named gateway's table (101) + guard; direct subnet gets no rule and no guard.
- Unknown gateway name → startup fails with a clear error (exit 1).
- `FORWARD_SUBNETS6` naming a v4-only gateway → startup fails with a clear error.
- Masquerade matrix: each subnet × (WAN + gateway egress interfaces).
- Regression: without the new variables, both scripts produce rulesets identical to 1.5.0-7.

shellcheck clean (no new findings).

## Backward compatibility

Both variables default to unset; the generated rulesets are unchanged unless they are used.