### PR TITLE
feat: VPN_GATEWAY/VPN_GATEWAY6 accept 'direct' and 'block'

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ You provide an `ocserv.conf` and a certificate in the config volume. Ready-to-us
 | `VPN_SUBNET` | `10.10.10.0/24` | VPN client subnet (must match `ipv4-network` in `ocserv.conf`) |
 | `WAN_IF` | _(auto)_ | WAN interface for NAT. Auto-detected from the container's default route (falls back to `eth0`); set explicitly to override |
 | `IPV6_NAT` | `0` | enable IPv6 masquerade (see the IPv6 notes on the wiki) |
-| `VPN_GATEWAY` | _(unset)_ | Route the client subnet out through an upstream gateway container (e.g. a NordVPN container with `FORWARD_FROM`) via source-based policy routing. Set to the gateway's IP. Adds a fail-closed nft kill switch (`inet ocserv_gw`) so client traffic can only leave toward the gateway. The gateway may sit on a different interface than `WAN_IF` (multi-network setups); its egress interface gets its own masquerade rule automatically. |
-| `VPN_GATEWAY6` | _(unset)_ | IPv6 gateway for gateway mode. If set, the IPv6 client subnet is policy-routed to it; if unset, forwarded client IPv6 is **dropped** to prevent leaks. |
+| `VPN_GATEWAY` | _(unset)_ | Default IPv4 egress for **unmapped** users. An **IP** routes the client subnet out through that upstream gateway container (e.g. a NordVPN container with `FORWARD_FROM`) via source-based policy routing, with a fail-closed nft kill switch (`inet ocserv_gw`); the gateway may sit on a different interface than `WAN_IF` (its egress gets its own masquerade automatically). `direct` (or unset) = exit via the ISP. `block` = reject their IPv4 (fail-closed). |
+| `VPN_GATEWAY6` | _(unset)_ | Default IPv6 egress for unmapped users. An **IP** policy-routes the IPv6 client subnet to it; `direct` = exit via the ISP; `block` (or unset) = reject their forwarded IPv6 to prevent leaks. |
 | `VPN_GATEWAY_TABLE` | `100` | Routing table used for gateway mode. |
 | `VPN_GATEWAY_RULE_PRIO` | `1000` | Priority of the `from <VPN_SUBNET>` policy rule. |
 | `VPN_GATEWAYS` | _(unset)_ | Named upstream gateways for per-user routing, e.g. `nl=172.28.0.2,us=172.28.0.4`. Each gets its own routing table and kill-switch set. |

--- a/rootfs/etc/s6-overlay/s6-rc.d/init-nat/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/init-nat/run
@@ -58,6 +58,7 @@ gw_dev() { # print the egress interface for a gateway IP ($1 = -4|-6, $2 = IP)
 
 gw_ifs4=""
 for gw in $vpn_gateway $(kv_pairs "$vpn_gateways" | awk '{print $2}'); do
+    case "$gw" in block|drop|direct|none) continue ;; esac
     dev="$(gw_dev -4 "$gw")"
     if [ -z "$dev" ]; then
         log_error "[INIT-NAT] Warning: cannot resolve egress interface for gateway $gw"
@@ -71,6 +72,7 @@ done
 
 gw_ifs6=""
 for gw in $vpn_gateway6 $(kv_pairs "$vpn_gateways6" | awk '{print $2}'); do
+    case "$gw" in block|drop|direct|none) continue ;; esac
     dev="$(gw_dev -6 "$gw")"
     if [ -z "$dev" ]; then
         log_error "[INIT-NAT] Warning: cannot resolve egress interface for gateway $gw"

--- a/rootfs/etc/s6-overlay/s6-rc.d/init-vpngw/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/init-vpngw/run
@@ -40,9 +40,17 @@ restore_config() {
 
 rm -rf "$vpngw_state_dir"
 
-if [ -z "$vpn_gateway" ] && [ -z "$vpn_gateways" ] && [ -z "$vpn_gateways_file" ]; then
+# Gateway mode is active if any egress control is configured. A v6 value of
+# "direct" (IPv6 via ISP) or unset counts as "not controlling IPv6", same as a
+# plain server; "block" or an IP does control it and activates the mode.
+gw_active=0
+[ -n "$vpn_gateway" ] && gw_active=1
+[ -n "$vpn_gateways" ] && gw_active=1
+[ -n "$vpn_gateways_file" ] && gw_active=1
+case "$vpn_gateway6" in ""|direct) ;; *) gw_active=1 ;; esac
+if [ "$gw_active" = 0 ]; then
     restore_config
-    log "[INIT-VPNGW] VPN_GATEWAY/VPN_GATEWAYS not set; clients exit via the default route"
+    log "[INIT-VPNGW] No gateway configured; clients exit via the default route"
     exit 0
 fi
 
@@ -120,23 +128,30 @@ if [ "$vpngw_user_mode" = 1 ]; then
     fi
 fi
 
-# ---- Default gateway: IPv4 routing -----------------------------------------
-if [ -n "$vpn_gateway" ]; then
-    log "[INIT-VPNGW] Routing $vpn_subnet via $vpn_gateway (table $table)"
-    ip route replace default via "$vpn_gateway" table "$table"
-    ip rule show | grep -q "from $vpn_subnet lookup $table" \
-        || ip rule add from "$vpn_subnet" lookup "$table" priority "$prio"
-
-    # ---- Default gateway: IPv6 routing (only with an upstream v6 gateway) ---
-    if [ -n "${vpn_gateway6:-}" ]; then
+# ---- Subnet default for unmapped users -------------------------------------
+# Policy-route the whole client subnet to the default gateway ONLY when it is a
+# real IP. "" (ISP) and "block" add no route: their traffic uses the main table
+# and the kill switch below either lets it out the WAN (ISP) or rejects it.
+case "$vpn_gateway" in
+    ""|block) : ;;
+    *)
+        log "[INIT-VPNGW] Routing $vpn_subnet via $vpn_gateway (table $table)"
+        ip route replace default via "$vpn_gateway" table "$table"
+        ip rule show | grep -q "from $vpn_subnet lookup $table" \
+            || ip rule add from "$vpn_subnet" lookup "$table" priority "$prio"
+        ;;
+esac
+case "$vpn_gateway6" in
+    ""|block|direct) : ;;
+    *)
         log "[INIT-VPNGW] Routing $ipv6_subnet via $vpn_gateway6 (table $table)"
         ip -6 route replace default via "$vpn_gateway6" table "$table" \
             || log_error "[INIT-VPNGW] Warning: could not add IPv6 gateway route"
         ip -6 rule show 2>/dev/null | grep -q "from $ipv6_subnet lookup $table" \
             || ip -6 rule add from "$ipv6_subnet" lookup "$table" priority "$prio" \
             || log_error "[INIT-VPNGW] Warning: could not add IPv6 policy rule"
-    fi
-fi
+        ;;
+esac
 
 # ---- Kill switch (defense in depth) --------------------------------------
 # The policy routes already force client traffic to the gateways, but if a
@@ -193,17 +208,31 @@ if [ -f "$vpngw_state_dir/users" ]; then
         ip6 saddr @v6_block reject with icmpv6 type admin-prohibited"
 fi
 
+# Subnet guard for unmapped users, per family:
+#   IP      -> next-hop guard (drop if it would leave by any other next-hop)
+#   ""      -> exit via ISP: no guard (their WAN traffic is accepted)
+#   block   -> reject their WAN-bound traffic (v6: all forwarded) fail-closed
+# These come AFTER the per-session rules above, so they only catch users not
+# handled by a named gateway / direct / block set.
 default_rules=""
-if [ -n "$vpn_gateway" ]; then
-    default_rules="ip saddr $vpn_subnet oifname \"$wan_if\" rt ip nexthop != $vpn_gateway drop"
-    if [ -n "${vpn_gateway6:-}" ]; then
-        default_rules="$default_rules
-        ip6 saddr $ipv6_subnet oifname \"$wan_if\" rt ip6 nexthop != $vpn_gateway6 drop"
+add_default_rule() {
+    if [ -z "$default_rules" ]; then
+        default_rules="$1"
     else
         default_rules="$default_rules
-        meta nfproto ipv6 iifname \"$vpn_ifname\" reject with icmpv6 type admin-prohibited"
+        $1"
     fi
-fi
+}
+case "$vpn_gateway" in
+    "")    : ;;
+    block) add_default_rule "ip saddr $vpn_subnet oifname \"$wan_if\" reject with icmp type admin-prohibited" ;;
+    *)     add_default_rule "ip saddr $vpn_subnet oifname \"$wan_if\" rt ip nexthop != $vpn_gateway drop" ;;
+esac
+case "$vpn_gateway6" in
+    direct)   : ;;
+    ""|block) add_default_rule "meta nfproto ipv6 iifname \"$vpn_ifname\" reject with icmpv6 type admin-prohibited" ;;
+    *)        add_default_rule "ip6 saddr $ipv6_subnet oifname \"$wan_if\" rt ip6 nexthop != $vpn_gateway6 drop" ;;
+esac
 
 nft delete table inet ocserv_gw 2>/dev/null || true
 if nft -f - <<EOF

--- a/rootfs/usr/local/bin/backend-functions
+++ b/rootfs/usr/local/bin/backend-functions
@@ -28,10 +28,19 @@ vpn_user_gateway_file="${VPN_USER_GATEWAY_FILE:-}"
 vpn_user_gateway_watch="${VPN_USER_GATEWAY_WATCH:-0}"
 vpn_gateway_user_rule_prio="${VPN_GATEWAY_USER_RULE_PRIO:-900}"
 
-# VPN_GATEWAY=direct is an explicit alias for "no default gateway": unmapped
-# users exit via the container's default route (the ISP)
-[ "$vpn_gateway" = "direct" ] && vpn_gateway=""
-[ "$vpn_gateway6" = "direct" ] && vpn_gateway6=""
+# Normalise the subnet-default gateway values (unmapped users). Each family
+# accepts an IP, "direct" (exit via the container's default route / ISP) or
+# "block" ("drop" is an alias; the family is rejected fail-closed):
+#   VPN_GATEWAY (v4):  "direct" and unset both mean ISP -> "";  result "", "block", IP
+#   VPN_GATEWAY6 (v6): unset means "block" (no IPv6 leak);      result "", "direct", "block", IP
+#                      ("" is treated as "block"; "direct" is kept distinct)
+case "$vpn_gateway" in
+    direct) vpn_gateway="" ;;
+    drop)   vpn_gateway="block" ;;
+esac
+case "$vpn_gateway6" in
+    drop) vpn_gateway6="block" ;;
+esac
 
 # Runtime state shared between init-vpngw and the ocserv connect/disconnect hook
 vpngw_state_dir="/run/ocserv-vpngw"

--- a/wiki/Configuration-Reference.md
+++ b/wiki/Configuration-Reference.md
@@ -14,8 +14,8 @@ These are read by the container's startup scripts (`backend-functions`) and driv
 | `IPV6_FORWARD` | `1` | Enable IPv6 forwarding sysctl inside the container. |
 | `IPV6_NAT` | `0` | Enable IPv6 masquerade for `IPV6_SUBNET`. Off by default — see the IPv6 warning below. |
 | `IPV6_SUBNET` | `fda9:4efe:7e3b:03ea::/64` | IPv6 ULA subnet to masquerade when `IPV6_NAT=1`. |
-| `VPN_GATEWAY` | _(unset)_ | Route the client subnet out through an upstream gateway container (e.g. a NordVPN container) instead of straight out the WAN. Set to the gateway's IP. Adds a fail-closed kill switch. The value `direct` is accepted as an explicit "no gateway" (same as unset). See [[Gateway Mode]]. |
-| `VPN_GATEWAY6` | _(unset)_ | Upstream IPv6 gateway. Set to route the IPv6 client subnet through it; unset means forwarded client IPv6 is dropped. See [[Gateway Mode]]. |
+| `VPN_GATEWAY` | _(unset)_ | Default IPv4 egress for **unmapped** users. An **IP** routes the client subnet out through that upstream gateway (fail-closed kill switch added); `direct` (or unset) exits via the ISP; `block` (`drop`) rejects their IPv4 fail-closed. See [[Gateway Mode]]. |
+| `VPN_GATEWAY6` | _(unset)_ | Default IPv6 egress for unmapped users. An **IP** policy-routes the IPv6 client subnet to it; `direct` exits via the ISP; `block` (or unset) rejects their forwarded IPv6 to prevent leaks. See [[Gateway Mode]]. |
 | `VPN_GATEWAY_TABLE` | `100` | Routing table used for the gateway default route. Named gateways from `VPN_GATEWAYS` use the following tables (101, 102, …). |
 | `VPN_GATEWAY_RULE_PRIO` | `1000` | Priority of the `from <VPN_SUBNET>` policy rule. |
 | `VPN_GATEWAYS` | _(unset)_ | Named upstream gateways for per-user routing, e.g. `nl=172.28.0.2,us=172.28.0.4`. See [Gateway Mode#per-user-gateways](Gateway-Mode#per-user-gateways). |

--- a/wiki/Gateway-Mode.md
+++ b/wiki/Gateway-Mode.md
@@ -15,8 +15,8 @@ Set `VPN_GATEWAY` to the upstream container's IP on the shared Docker network:
 
 | Variable | Default | Description |
 |---|---|---|
-| `VPN_GATEWAY` | _(unset)_ | Upstream gateway IP. Steers `VPN_SUBNET` to it and installs the kill switch. Unset or `direct` = normal standalone ocserv (clients exit via the ISP). |
-| `VPN_GATEWAY6` | _(unset)_ | Upstream IPv6 gateway. Set it to route the IPv6 client subnet too; unset = forwarded client IPv6 is dropped. |
+| `VPN_GATEWAY` | _(unset)_ | Default IPv4 egress for unmapped users: an **IP** (steer `VPN_SUBNET` to it + kill switch), `direct`/unset (exit via the ISP), or `block` (reject their IPv4). |
+| `VPN_GATEWAY6` | _(unset)_ | Default IPv6 egress for unmapped users: an **IP** (route `IPV6_SUBNET` to it), `direct` (exit via the ISP), or `block`/unset (reject their IPv6). |
 | `VPN_GATEWAY_TABLE` | `100` | Routing table used for the gateway default route. Named gateways use the following tables (101, 102, …). |
 | `VPN_GATEWAY_RULE_PRIO` | `1000` | Priority of the `from <VPN_SUBNET>` policy rule. |
 | `VPN_GATEWAYS` | _(unset)_ | Named gateways for [per-user routing](#per-user-gateways), e.g. `nl=172.28.0.2,us=172.28.0.4`. |
@@ -27,7 +27,7 @@ Set `VPN_GATEWAY` to the upstream container's IP on the shared Docker network:
 | `VPN_USER_GATEWAY_WATCH` | `0` | `1` = auto-`vpngw-reload` when the map file changes. |
 | `VPN_GATEWAY_USER_RULE_PRIO` | `900` | Priority of the per-user policy rules (wins over the subnet rule). |
 
-When `VPN_GATEWAY` and `VPN_GATEWAYS` are unset, the `init-vpngw` service is a no-op — ocserv behaves exactly as a standalone server (including normal IPv6).
+When no egress control is set — `VPN_GATEWAY`/`VPN_GATEWAYS`/`VPN_GATEWAYS_FILE` unset and `VPN_GATEWAY6` unset or `direct` — the `init-vpngw` service is a no-op and ocserv behaves exactly as a standalone server (including normal IPv6). Setting any of them (including `VPN_GATEWAY6=block`) activates gateway mode.
 
 ## How it works
 
@@ -66,8 +66,11 @@ In every case clients lose internet rather than leaking out the host's real IP.
 
 ## IPv6
 
-- **Upstream is IPv4-only** (the NordVPN container is, by default): leave `VPN_GATEWAY6` unset. Forwarded client IPv6 is dropped so it can't bypass the IPv4 policy rule.
+- **Upstream is IPv4-only** (the NordVPN container is, by default): leave `VPN_GATEWAY6` unset (or set it to `block`). Forwarded client IPv6 is **rejected** (ICMPv6 admin-prohibited) so it can't bypass the IPv4 policy rule, and clients fall back to IPv4 fast.
 - **Upstream is dual-stack**: set `VPN_GATEWAY6` to its IPv6 address. ocserv policy-routes `IPV6_SUBNET` to it with the same fail-closed next-hop guard. This also needs working IPv6 on the Docker network and the upstream forwarding IPv6 (see [Networking NAT and Routing#ipv6](Networking-NAT-and-Routing#ipv6)).
+- **Keep IPv6 on the ISP**: set `VPN_GATEWAY6=direct` to send unmapped users' IPv6 out the container's own connection while their IPv4 goes through the gateway. Note this exposes their real IPv6 address — only use it when that's intended.
+
+The same three forms (an IP, `direct`, `block`) apply to `VPN_GATEWAY` for IPv4: an IP tunnels unmapped users, `direct`/unset sends them out the ISP, and `block` rejects their IPv4 entirely.
 
 ## Per-user gateways
 


### PR DESCRIPTION
## Summary

Give the **subnet default** (the egress for users *not* in `VPN_USER_GATEWAY`) the same per-family vocabulary as named gateways. Each of `VPN_GATEWAY` (IPv4) and `VPN_GATEWAY6` (IPv6) now accepts:

| Value | Meaning |
|---|---|
| an **IP** | route the client subnet via that upstream gateway (as before) |
| **`direct`** | exit via the container's default route (the ISP) |
| **`block`** (`drop`) | reject that family fail-closed (ICMP/ICMPv6 admin-prohibited) |

So `VPN_GATEWAY6=block` blocks IPv6 for unmapped users, `VPN_GATEWAY=block` blocks their IPv4, and `VPN_GATEWAY6=direct` keeps IPv6 on the ISP while IPv4 tunnels.

## Defaults & the one fix

- `VPN_GATEWAY` unset ≡ `direct` (ISP) — unchanged.
- `VPN_GATEWAY6` unset ≡ `block` (no IPv6 leak) — unchanged.
- **Fix:** `VPN_GATEWAY6=direct` previously folded into unset (→ blocked). It now means *IPv6 via ISP*, distinct from `block`.

## Changes

- **`backend-functions`**: normalise each var per family (`direct`/`drop`; v4 folds `direct`→ISP, v6 keeps `direct` distinct).
- **`init-vpngw`**: activate gateway mode when either family is `block` or an IP (so `VPN_GATEWAY6=block` alone works); policy-route only for real IPs; build the subnet kill-switch guard per family — IP → next-hop `drop` guard, `block` → `reject`, `direct`/ISP → no rule. Ordering keeps per-session (named/direct/block) rules ahead of the subnet guard.
- **`init-nat`**: skip the `block`/`direct`/`drop` keywords when resolving gateway egress interfaces (no spurious warnings, no bogus route lookups).

## Testing

- **Full matrix** for both families (IP / direct / block / unset) verified against the generated `inet ocserv_gw` table: next-hop guards for IPs, `reject` for block, no rule for direct/ISP; `VPN_GATEWAY6=block` alone activates; `VPN_GATEWAY=direct` alone stays a plain no-op server.
- **Reject syntax validated on real nftables 1.1.6** (`nft -c`) on a live host.
- **init-nat**: `VPN_GATEWAY=block` produces no warning; a real v4 gateway still gets its egress masquerade while `VPN_GATEWAY6=direct` is skipped.
- `sh -n` + shellcheck clean.

## Backward compatibility

Env-only IP deployments are unchanged. `VPN_GATEWAY=direct`/unset behaves as before. The only behavior change is the intended `VPN_GATEWAY6=direct` fix described above.