### PR TITLE
vpngw: opt-in Docker health monitor (HEALTH_CHECK_ENABLED)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -152,6 +152,12 @@ COPY --from=rootfs /rootfs/ /
 # Runtime knobs
 ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0
 
+# Report container health from the server state. start-period covers ocserv
+# startup including gateway/bypass initialization and pool loading.
+# Opt-in: the probe reports healthy unless HEALTH_CHECK_ENABLED=true is set.
+HEALTHCHECK --interval=60s --timeout=15s --start-period=60s --retries=3 \
+    CMD ["/usr/local/bin/healthcheck"]
+
 VOLUME ["/etc/ocserv"]
 EXPOSE 443/tcp 443/udp
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ OpenConnect VPN server ([ocserv](https://ocserv.gitlab.io/www/)) in a small self
 - **🛡️ Fail-closed kill switch** — nftables next-hop guards on every routed path: if an upstream is down, clients lose internet rather than leak ([details][wiki-killswitch])
 - **🔄 Hot-reload everything** — user maps, pool lists, DNS-named gateway addresses and TLS certificates all reload live, without dropping sessions ([details][wiki-reload])
 - **🔒 Reverse-proxy & Let's Encrypt friendly** — share SWAG's certificates; renewals are picked up without a restart ([details][wiki-certs])
+- **🩺 Opt-in health monitor** — Docker-native `HEALTHCHECK`: server liveness, routing integrity, and (optionally) real egress probes per gateway ([details][wiki-health])
 - **📵 IPv6 without leaks** — optional NAT66; when an upstream has no IPv6, client IPv6 is rejected fail-closed instead of escaping ([details][wiki-ipv6])
 - **📦 Multi-arch, from source** — amd64 / arm64 / riscv64 images, ocserv built from source, supervised by s6-overlay
 
@@ -151,6 +152,14 @@ Grouped by feature; every variable is one line here — the **[Configuration Ref
 | `VPN_BYPASS_RULE_PRIO` | `800` | Priority of the bypass policy rules (advanced). |
 | `VPN_BYPASS_MARK` | `0xbc` | Base fwmark for bypassed traffic (advanced). |
 
+### Health monitor — [details][wiki-health]
+
+| Variable | Default | Description |
+|---|---|---|
+| `HEALTH_CHECK_ENABLED` | `false` | `true` = the Docker `HEALTHCHECK` probe checks server liveness + routing integrity. |
+| `HEALTH_CHECK_EGRESS` | _(unset)_ | Egress paths that also gate health: `direct`, gateway names, `default`, `all` (join with `+`). |
+| `HEALTH_CHECK_URL` | `https://1.1.1.1/…` | URL(s) for the direct egress probe, `;`-separated. |
+
 ### Certificate hot-reload — [details][wiki-certs]
 
 | Variable | Default | Description |
@@ -219,6 +228,7 @@ MIT — see [LICENSE](LICENSE).
 [wiki-network]: https://github.com/azinchen/ocserv-server/wiki/Networking-NAT-and-Routing
 [wiki-ipv6]: https://github.com/azinchen/ocserv-server/wiki/Networking-NAT-and-Routing#ipv6
 [wiki-certs]: https://github.com/azinchen/ocserv-server/wiki/Reverse-Proxy-and-Certificates
+[wiki-health]: https://github.com/azinchen/ocserv-server/wiki/Health-Monitor
 [wiki-clients]: https://github.com/azinchen/ocserv-server/wiki/Clients-and-Devices
 [wiki-troubleshoot]: https://github.com/azinchen/ocserv-server/wiki/Troubleshooting
 [wiki-faq]: https://github.com/azinchen/ocserv-server/wiki/FAQ

--- a/rootfs/usr/local/bin/backend-functions
+++ b/rootfs/usr/local/bin/backend-functions
@@ -49,6 +49,9 @@ vpn_bypass_sources_file="${VPN_BYPASS_SOURCES_FILE:-}"
 vpn_bypass_update_interval="${VPN_BYPASS_UPDATE_INTERVAL:-0}"
 cert_watch="${CERT_WATCH:-0}"
 cert_watch_interval="${CERT_WATCH_INTERVAL:-0}"
+health_check_enabled="${HEALTH_CHECK_ENABLED:-false}"
+health_check_egress="${HEALTH_CHECK_EGRESS:-}"
+health_check_url="${HEALTH_CHECK_URL:-https://1.1.1.1/cdn-cgi/trace}"
 ocserv_config="${OCSERV_CONFIG:-/etc/ocserv/ocserv.conf}"
 
 # Normalise the subnet-default gateway values (unmapped users). Each family
@@ -835,6 +838,113 @@ vpngw_reconcile_gateways() {
         fi
     fi
     return 0
+}
+
+# ---- Egress probe machinery (shared: network-diagnostic, healthcheck) ------
+# Sends locally generated test traffic through a chosen routing table (or a
+# live bypass fwmark rule) to verify an egress path end to end, without
+# touching any live rule: a temporary route-type output chain fwmarks traffic
+# to the test destination only, a mark-scoped masquerade handles multi-
+# interface deployments, and an "fwmark -> <table>" policy rule steers it.
+# Forwarded (client) traffic is never marked - the chain hooks output only.
+#
+# Each consumer sets its OWN table/mark/prio triple before probe_arm so two
+# probers never collide (network-diagnostic: ocserv_diag/0xd1a6/790,
+# healthcheck: ocserv_health/0xd1a7/791) and must call probe_cleanup on exit
+# (trap). Docker serializes health probes; the diagnostic is run manually.
+PROBE_TABLE="${PROBE_TABLE:-ocserv_diag}"
+PROBE_MARK="${PROBE_MARK:-0xd1a6}"
+PROBE_PRIO="${PROBE_PRIO:-790}"
+PROBE_TEST4="1.1.1.1"
+PROBE_TEST6="2606:4700:4700::1111"
+PROBE_TRACE4="https://1.1.1.1/cdn-cgi/trace"
+PROBE_TRACE6="https://[2606:4700:4700::1111]/cdn-cgi/trace"
+PROBE_WGET_TIMEOUT="${PROBE_WGET_TIMEOUT:-8}"
+PROBE_ARMED=0
+
+fetch_url() { # $1 = url; prints the body (busybox wget, no cert verification)
+    wget -q -T "$PROBE_WGET_TIMEOUT" -O - "$1" 2>/dev/null
+}
+
+probe_cleanup() {
+    [ "$PROBE_ARMED" = 1 ] || return 0
+    _pc_n=0
+    while [ "$_pc_n" -lt 8 ] && ip rule del priority "$PROBE_PRIO" 2>/dev/null; do
+        _pc_n=$((_pc_n + 1))
+    done
+    _pc_n=0
+    while [ "$_pc_n" -lt 8 ] && ip -6 rule del priority "$PROBE_PRIO" 2>/dev/null; do
+        _pc_n=$((_pc_n + 1))
+    done
+    nft delete table inet "$PROBE_TABLE" 2>/dev/null || true
+    PROBE_ARMED=0
+}
+
+probe_arm() {
+    [ "$PROBE_ARMED" = 1 ] && return 0
+    if nft -f - <<EOF
+table inet $PROBE_TABLE {
+    chain output {
+        type route hook output priority mangle; policy accept;
+    }
+    chain postrouting {
+        type nat hook postrouting priority 110; policy accept;
+    }
+}
+EOF
+    then
+        PROBE_ARMED=1
+        return 0
+    fi
+    return 1
+}
+
+# Remove the per-probe marking rules; MUST be called after a probe block so a
+# leftover mark rule cannot steer later plain fetches through a gateway table.
+probe_rules_clear() {
+    nft flush chain inet "$PROBE_TABLE" output 2>/dev/null
+    nft flush chain inet "$PROBE_TABLE" postrouting 2>/dev/null
+}
+
+probe_set_mark() { # $1 = family 4|6, $2 = mark: mark+masquerade probe traffic only
+    probe_rules_clear
+    if [ "$1" = 4 ]; then
+        nft add rule inet "$PROBE_TABLE" output ip daddr "$PROBE_TEST4" tcp dport 443 meta mark set "$2" \
+            && nft add rule inet "$PROBE_TABLE" postrouting ip daddr "$PROBE_TEST4" meta mark "$2" masquerade
+    else
+        nft add rule inet "$PROBE_TABLE" output ip6 daddr "$PROBE_TEST6" tcp dport 443 meta mark set "$2" \
+            && nft add rule inet "$PROBE_TABLE" postrouting ip6 daddr "$PROBE_TEST6" meta mark "$2" masquerade
+    fi
+}
+
+probe_fetch_raw() { # $1 = family 4|6; prints the cdn-cgi/trace body
+    if [ "$1" = 4 ]; then
+        _pf_body="$(fetch_url "$PROBE_TRACE4")"
+    else
+        _pf_body="$(fetch_url "$PROBE_TRACE6")"
+    fi
+    [ -n "$_pf_body" ] || return 1
+    printf '%s\n' "$_pf_body"
+}
+
+probe_table_raw() { # $1 = table (or "main"), $2 = family 4|6; prints trace body
+    probe_set_mark "$2" "$PROBE_MARK" >/dev/null 2>&1 || return 1
+    if [ "$2" = 4 ]; then
+        ip rule add fwmark "$PROBE_MARK" lookup "$1" priority "$PROBE_PRIO" 2>/dev/null || return 1
+        _pt_r="$(probe_fetch_raw 4)"; _pt_rc=$?
+        ip rule del priority "$PROBE_PRIO" 2>/dev/null
+    else
+        ip -6 rule add fwmark "$PROBE_MARK" lookup "$1" priority "$PROBE_PRIO" 2>/dev/null || return 1
+        _pt_r="$(probe_fetch_raw 6)"; _pt_rc=$?
+        ip -6 rule del priority "$PROBE_PRIO" 2>/dev/null
+    fi
+    [ "$_pt_rc" = 0 ] || return 1
+    printf '%s\n' "$_pt_r"
+}
+
+probe_mark_raw() { # $1 = mark, $2 = family: rely on the LIVE bypass fwmark rules
+    probe_set_mark "$2" "$1" >/dev/null 2>&1 || return 1
+    probe_fetch_raw "$2"
 }
 
 # ---- certificate hot-reload -----------------------------------------------

--- a/rootfs/usr/local/bin/healthcheck
+++ b/rootfs/usr/local/bin/healthcheck
@@ -1,0 +1,154 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Side-effect-free liveness probe for the Docker HEALTHCHECK instruction:
+# never sleeps, never retries internally, never touches live vpngw state.
+# Docker's --interval/--timeout/--retries govern retry and failure behaviour,
+# and Docker stores this script's one-line output in .State.Health.Log, so
+# `docker inspect` shows WHY the container went unhealthy.
+#
+# The HEALTHCHECK instruction is baked into the image and always fires; the
+# probe reports healthy without checking anything unless HEALTH_CHECK_ENABLED
+# is "true" (same opt-in pattern as the openconnect-client sibling image).
+#
+# What gates health:
+#   always          ocserv process, TCP listener, occtl responding
+#   automatically   NAT table; kill-switch/bypass tables when those features
+#                   are configured (routing-integrity drift)
+#   opt-in          egress data-plane probes per path (HEALTH_CHECK_EGRESS):
+#                   "direct", named gateway(s), "default", or "all". Gateway
+#                   probes use the shared fwmark machinery with a DEDICATED
+#                   table/mark/prio (ocserv_health/0xd1a7/791), so a manual
+#                   network-diagnostic run can never collide with a probe.
+#
+# Gateway egress is opt-in ON PURPOSE: an upstream tunnel being down makes the
+# CONTAINER unhealthy only if you say so - restart automation reacting to it
+# would restart ocserv, which cannot fix an upstream and would drop every
+# session. Gate on the paths whose failure you would act on.
+
+set -u
+
+. /usr/local/bin/backend-functions
+
+[ "$health_check_enabled" = "true" ] || exit 0
+
+# This prober's identity - MUST differ from network-diagnostic's
+PROBE_TABLE="ocserv_health"
+PROBE_MARK="0xd1a7"
+PROBE_PRIO=791
+PROBE_WGET_TIMEOUT=4
+
+fail() { echo "unhealthy: $*"; exit 1; }
+
+# ---- Tier 1: server liveness ------------------------------------------------
+
+OCSERV_PID="$(pidof ocserv 2>/dev/null | awk '{ print $1 }')" || OCSERV_PID=""
+[ -n "$OCSERV_PID" ] || fail "ocserv process not running"
+
+_port="$(sed -n 's/^[[:space:]]*tcp-port[[:space:]]*=[[:space:]]*//p' "$ocserv_config" 2>/dev/null \
+    | head -1 | sed 's/[[:space:]]*#.*//; s/"//g')"
+_port="${_port:-443}"
+netstat -tln 2>/dev/null | grep -q ":$_port " || fail "no TCP listener on port $_port"
+
+occtl show status >/dev/null 2>&1 || fail "occtl not responding (sec-mod wedged?)"
+
+# ---- Tier 2: routing integrity ------------------------------------------------
+
+nft list table inet ocserv >/dev/null 2>&1 || fail "NAT table (inet ocserv) missing"
+if [ -d "$vpngw_state_dir" ]; then
+    nft list table inet ocserv_gw >/dev/null 2>&1 \
+        || fail "gateway mode active but kill-switch table (inet ocserv_gw) missing"
+    if [ -f "$vpngw_state_dir/bypass_pools" ]; then
+        nft list table inet ocserv_bypass >/dev/null 2>&1 \
+            || fail "destination bypass configured but its table (inet ocserv_bypass) missing"
+    fi
+fi
+
+# ---- Tier 3: egress data plane (opt-in per path) ------------------------------
+
+EGRESS_OK=""
+
+# One fetch per configured URL until one succeeds (direct path only - custom
+# URLs may resolve anywhere, so they cannot be pinned into gateway probes)
+direct_ok() {
+    _oldifs="$IFS"; IFS=';,'
+    for _u in $health_check_url; do
+        [ -n "$_u" ] || continue
+        if wget -q -T 4 -O /dev/null "$_u" 2>/dev/null; then
+            IFS="$_oldifs"
+            return 0
+        fi
+    done
+    IFS="$_oldifs"
+    return 1
+}
+
+# Probe every family a gateway routes through its table
+gateway_ok() { # $1 = name, $2 = table, $3 = gw4, $4 = gw6
+    if [ "$3" != "block" ]; then
+        probe_table_raw "$2" 4 >/dev/null || fail "egress via gateway '$1' (table $2) failed for IPv4"
+    fi
+    if [ "$4" != "block" ]; then
+        probe_table_raw "$2" 6 >/dev/null || fail "egress via gateway '$1' (table $2) failed for IPv6"
+    fi
+    return 0
+}
+
+if [ -n "$health_check_egress" ]; then
+    trap probe_cleanup EXIT INT TERM
+
+    # Expand the list; "all" = direct + the subnet default (when routed) +
+    # every named gateway
+    _paths="$(printf '%s' "$health_check_egress" | tr '+,' '  ')"
+    case " $_paths " in
+        *" all "*)
+            _paths="direct"
+            if [ -f "$vpngw_state_dir/subnet" ]; then
+                read -r _s4 _ < "$vpngw_state_dir/subnet" 2>/dev/null || _s4="-"
+                case "$_s4" in -|block) : ;; *) _paths="$_paths default" ;; esac
+            fi
+            [ -f "$vpngw_state_dir/gateways" ] \
+                && _paths="$_paths $(awk '{ printf "%s ", $1 }' "$vpngw_state_dir/gateways")"
+            ;;
+    esac
+
+    for _p in $_paths; do
+        case "$_p" in
+            direct)
+                direct_ok || fail "direct egress failed (${health_check_url%%[;,]*})"
+                ;;
+            default)
+                [ -f "$vpngw_state_dir/subnet" ] || fail "HEALTH_CHECK_EGRESS lists 'default' but no default gateway is configured"
+                read -r _s4 _s6 < "$vpngw_state_dir/subnet" 2>/dev/null || { _s4="-"; _s6="-"; }
+                # A family the subnet default does not route ("-", "block",
+                # v6 "direct") maps to block = skipped by gateway_ok
+                case "${_s4:--}" in -|block) _s4="block" ;; esac
+                case "${_s6:--}" in -|block|direct) _s6="block" ;; esac
+                [ "$_s4$_s6" = "blockblock" ] \
+                    && fail "HEALTH_CHECK_EGRESS lists 'default' but the default gateway routes nothing"
+                probe_arm || fail "could not install the probe chain"
+                gateway_ok "default" "$vpn_gateway_table" "$_s4" "$_s6"
+                ;;
+            *)
+                _line="$(awk -v n="$_p" '$1 == n { print; exit }' "$vpngw_state_dir/gateways" 2>/dev/null)"
+                [ -n "$_line" ] || fail "HEALTH_CHECK_EGRESS lists unknown gateway '$_p'"
+                probe_arm || fail "could not install the probe chain"
+                gateway_ok "$_p" \
+                    "$(echo "$_line" | awk '{ print $2 }')" \
+                    "$(echo "$_line" | awk '{ print $3 }')" \
+                    "$(echo "$_line" | awk '{ print $4 }')"
+                ;;
+        esac
+        EGRESS_OK="$EGRESS_OK${EGRESS_OK:+,}$_p"
+    done
+    probe_cleanup
+fi
+
+# ---- Healthy ------------------------------------------------------------------
+
+CLIENTS=""
+if [ -d "$vpngw_state_dir/sessions" ]; then
+    CLIENTS="$(find "$vpngw_state_dir/sessions" -type f 2>/dev/null | wc -l)"
+fi
+echo "healthy: ocserv up (pid $OCSERV_PID)${CLIENTS:+, $CLIENTS client(s)}${EGRESS_OK:+; egress ok: $EGRESS_OK}"
+exit 0

--- a/rootfs/usr/local/bin/network-diagnostic
+++ b/rootfs/usr/local/bin/network-diagnostic
@@ -72,12 +72,13 @@ done
 
 . /usr/local/bin/backend-functions
 
-TEST4="1.1.1.1"
-TEST6="2606:4700:4700::1111"
-TRACE4="https://1.1.1.1/cdn-cgi/trace"
-TRACE6="https://[2606:4700:4700::1111]/cdn-cgi/trace"
-DIAG_MARK="0xd1a6"
-DIAG_RULE_PRIO=790
+# Probe identity: this script uses the shared defaults from backend-functions
+# (table ocserv_diag, mark 0xd1a6, prio 790); healthcheck uses its own triple,
+# so the two probers never collide.
+TEST4="$PROBE_TEST4"
+TEST6="$PROBE_TEST6"
+TRACE4="$PROBE_TRACE4"
+TRACE6="$PROBE_TRACE6"
 DIAG_TMP="/tmp/ocserv-diag.$$"
 DIAG_GEO="/tmp/ocserv-diag-geo.$$"
 
@@ -106,10 +107,6 @@ mask2len() { # 255.255.255.0 -> 24
     echo "$1" | awk -F. '{ n = 0
         for (i = 1; i <= 4; i++) { x = $i; while (x > 0) { n += x % 2; x = int(x / 2) } }
         print n }'
-}
-
-fetch_url() { # $1 = url; prints the body (busybox wget, no cert verification)
-    wget -q -T 8 -O - "$1" 2>/dev/null
 }
 
 # Probe a URL: prints "200" when the fetch succeeded, the status code parsed
@@ -226,95 +223,30 @@ dev_counters_raw() { # $1 = device -> "rx tx" in bytes (empty if unknown)
     echo "$(cat "/sys/class/net/$1/statistics/rx_bytes") $(cat "/sys/class/net/$1/statistics/tx_bytes")"
 }
 
-# ---- Egress probe machinery -------------------------------------------------
-# Armed once (empty chains), cleaned up on exit. Each probe installs its own
-# marking + masquerade rules (scoped to the probe destination), runs, and the
-# next probe flushes them.
-
-PROBES_ARMED=0
+# ---- Egress probe machinery (shared helpers live in backend-functions) -------
+# diag_probe_* wrap the shared probe_* helpers with this script's temp-file
+# cleanup and geo-enriched output formatting.
 
 diag_probe_cleanup() {
     rm -f "$DIAG_TMP" "$DIAG_GEO"
-    [ "$PROBES_ARMED" = 1 ] || return 0
-    _n=0
-    while [ "$_n" -lt 8 ] && ip rule del priority "$DIAG_RULE_PRIO" 2>/dev/null; do
-        _n=$((_n + 1))
-    done
-    _n=0
-    while [ "$_n" -lt 8 ] && ip -6 rule del priority "$DIAG_RULE_PRIO" 2>/dev/null; do
-        _n=$((_n + 1))
-    done
-    nft delete table inet ocserv_diag 2>/dev/null || true
-    PROBES_ARMED=0
+    probe_cleanup
 }
 trap diag_probe_cleanup EXIT INT TERM
 
 diag_probe_arm() {
-    [ "$PROBES_ARMED" = 1 ] && return 0
-    if nft -f - <<EOF
-table inet ocserv_diag {
-    chain output {
-        type route hook output priority mangle; policy accept;
-    }
-    chain postrouting {
-        type nat hook postrouting priority 110; policy accept;
-    }
-}
-EOF
-    then
-        PROBES_ARMED=1
-        return 0
-    fi
+    probe_arm && return 0
     info "could not install the probe chain; egress probes skipped"
     return 1
 }
 
-# Remove the per-probe marking rules; MUST be called after a probe block so a
-# leftover mark rule cannot steer later plain fetches through a gateway table.
-probe_rules_clear() {
-    nft flush chain inet ocserv_diag output 2>/dev/null
-    nft flush chain inet ocserv_diag postrouting 2>/dev/null
-}
-
-probe_set_mark() { # $1 = family 4|6, $2 = mark: mark+masquerade probe traffic only
-    probe_rules_clear
-    if [ "$1" = 4 ]; then
-        nft add rule inet ocserv_diag output ip daddr "$TEST4" tcp dport 443 meta mark set "$2" \
-            && nft add rule inet ocserv_diag postrouting ip daddr "$TEST4" meta mark "$2" masquerade
-    else
-        nft add rule inet ocserv_diag output ip6 daddr "$TEST6" tcp dport 443 meta mark set "$2" \
-            && nft add rule inet ocserv_diag postrouting ip6 daddr "$TEST6" meta mark "$2" masquerade
-    fi
-}
-
-probe_fetch() { # $1 = family 4|6; prints "IP (City, CC - org)"
-    if [ "$1" = 4 ]; then
-        _pf_body="$(fetch_url "$TRACE4")"
-    else
-        _pf_body="$(fetch_url "$TRACE6")"
-    fi
-    [ -n "$_pf_body" ] || return 1
-    trace_pretty "$_pf_body"
-}
-
-probe_via_table() { # $1 = table (or "main"), $2 = family 4|6
-    probe_set_mark "$2" "$DIAG_MARK" >/dev/null 2>&1 || return 1
-    if [ "$2" = 4 ]; then
-        ip rule add fwmark "$DIAG_MARK" lookup "$1" priority "$DIAG_RULE_PRIO" 2>/dev/null || return 1
-        _pv_r="$(probe_fetch 4)"; _pv_rc=$?
-        ip rule del priority "$DIAG_RULE_PRIO" 2>/dev/null
-    else
-        ip -6 rule add fwmark "$DIAG_MARK" lookup "$1" priority "$DIAG_RULE_PRIO" 2>/dev/null || return 1
-        _pv_r="$(probe_fetch 6)"; _pv_rc=$?
-        ip -6 rule del priority "$DIAG_RULE_PRIO" 2>/dev/null
-    fi
-    [ "$_pv_rc" = 0 ] || return 1
-    printf '%s\n' "$_pv_r"
+probe_via_table() { # $1 = table (or "main"), $2 = family; prints "IP (City, CC - org)"
+    _pv_b="$(probe_table_raw "$1" "$2")" || return 1
+    trace_pretty "$_pv_b"
 }
 
 probe_via_mark() { # $1 = mark, $2 = family: rely on the LIVE bypass fwmark rules
-    probe_set_mark "$2" "$1" >/dev/null 2>&1 || return 1
-    probe_fetch "$2"
+    _pm_b="$(probe_mark_raw "$1" "$2")" || return 1
+    trace_pretty "$_pm_b"
 }
 
 ping_probe() { # $1 = family 4|6, $2 = address -> "reachable (X ms)" | "NO REPLY"

--- a/wiki/Architecture-and-Internals.md
+++ b/wiki/Architecture-and-Internals.md
@@ -84,7 +84,7 @@ All env-var defaults live in one helper, `/usr/local/bin/backend-functions`, whi
 | `/usr/sbin/ocserv`, `/usr/sbin/ocserv-worker` | The server |
 | `/usr/bin/occtl`, `/usr/bin/ocpasswd` | Control + user tools |
 | `/usr/libexec/ocserv-fw` | Per-user firewall helper (nftables) |
-| `/usr/local/bin/` | Helper scripts: `backend-functions` (shared env/config helpers) and the admin commands `network-diagnostic`, `vpngw-reload`, `vpngw-gw-resolve`, `bypass-reload`, `bypass-fetch`, `cert-reload` (all runnable via `docker exec`) |
+| `/usr/local/bin/` | Helper scripts: `backend-functions` (shared env/config helpers) and the admin commands `network-diagnostic`, `healthcheck` (the Docker health probe), `vpngw-reload`, `vpngw-gw-resolve`, `bypass-reload`, `bypass-fetch`, `cert-reload` (all runnable via `docker exec`) |
 | `/etc/ocserv/pools/` | Destination-bypass pool lists (`<name>.list`, on your volume) |
 | `/run/ocserv/` | PID + control sockets |
 | `/run/ocserv-vpngw/` | Gateway/bypass runtime state (parsed gateways, user maps, per-session records) |

--- a/wiki/Configuration-Reference.md
+++ b/wiki/Configuration-Reference.md
@@ -13,6 +13,7 @@ These are read by the container's startup scripts (`backend-functions`) and driv
 | [Gateway mode](#gateway-mode) | Routing clients out through upstream VPNs | [[Gateway Mode]] |
 | [Destination bypass](#destination-bypass) | Routing by destination (pools, targets) | [[Destination Bypass]] |
 | [Certificate hot-reload](#certificate-hot-reload) | Reloading renewed TLS certs without restart | [[Reverse Proxy and Certificates]] |
+| [Health monitor](#health-monitor) | Docker-native health probe | [[Health Monitor]] |
 
 ### Core networking
 
@@ -77,6 +78,16 @@ Route traffic **by destination**: CIDR pools whose matched traffic exits direct,
 |---|---|---|
 | `CERT_WATCH` | `0` | When `1`, the `svc-cert-watch` service watches the `server-cert`/`server-key` files declared in `ocserv.conf` and sends ocserv a `SIGHUP` (via `cert-reload`) whenever one changes, so a renewed certificate is reloaded **without a container restart** and without dropping live sessions. Relative cert paths are resolved against the `ocserv.conf` directory. Run `docker exec <container> cert-reload` to force one reload. See [Reverse Proxy and Certificates#certificate-renewal](Reverse-Proxy-and-Certificates#certificate-renewal). |
 | `CERT_WATCH_INTERVAL` | `0` | Polling fallback for `CERT_WATCH`, in seconds (`0` = off). When positive, `svc-cert-poll` re-stats the same cert files every N seconds and reloads ocserv when their mtime/size changes — for filesystems where `inotify` doesn't deliver events (e.g. an **NFS-backed** cert directory). `stat` follows symlinks, so a certbot `live`→`archive` re-link is detected. Prefer `CERT_WATCH=1` on local/bind-mounted directories; use this where inotify can't work. Both may be set (reloads are idempotent), but normally you pick one. |
+
+### Health monitor
+
+Opt-in Docker `HEALTHCHECK` probe. Feature guide: [[Health Monitor]].
+
+| Variable | Default | Description |
+|---|---|---|
+| `HEALTH_CHECK_ENABLED` | `false` | Master switch. The baked `HEALTHCHECK` instruction always fires; when this is not `true` the probe reports healthy without checking anything. When enabled it gates on server liveness (process, listener, `occtl`) and routing integrity (NAT/kill-switch/bypass tables present when configured). |
+| `HEALTH_CHECK_EGRESS` | _(unset)_ | Egress paths that also gate health, joined with `+`: `direct`, named gateway(s), `default`, or `all` — each is verified with a real HTTPS fetch through its routing table. Opt-in on purpose: an upstream failure should flip container health only if you would act on it (restarting ocserv cannot fix an upstream). See [Health Monitor#why-gateway-egress-is-opt-in](Health-Monitor#why-gateway-egress-is-opt-in). |
+| `HEALTH_CHECK_URL` | `https://1.1.1.1/cdn-cgi/trace` | URL(s) for the **direct** egress probe, `;`-separated, first success wins. Gateway probes use the built-in IP-literal endpoint. |
 
 > **About `PUID`/`PGID`:** this image does **not** implement LinuxServer-style `PUID`/`PGID` user remapping. Setting them has no effect; ocserv drops privileges internally via the `run-as-user`/`run-as-group` directives in `ocserv.conf`.
 

--- a/wiki/Health-Monitor.md
+++ b/wiki/Health-Monitor.md
@@ -1,0 +1,62 @@
+# Health Monitor
+
+An opt-in **Docker-native health probe**: the image bakes a `HEALTHCHECK` instruction, and a small side-effect-free script decides whether the container is healthy. When the feature is off (the default) the probe always reports healthy and costs nothing — the same pattern as the sibling `openconnect-client` image.
+
+```yaml
+environment:
+  - HEALTH_CHECK_ENABLED=true
+  - HEALTH_CHECK_EGRESS=direct+bal     # optional: gate health on real egress paths
+```
+
+`docker ps` then shows `(healthy)` / `(unhealthy)`, and orchestration (compose `depends_on: condition: service_healthy`, swarm, autoheal-style watchers, monitoring that reads `docker inspect`) can react.
+
+## What gates health
+
+| Tier | Checks | When |
+|---|---|---|
+| **Server liveness** | ocserv process running · TCP listener on the `tcp-port` · `occtl` responding (a wedged sec-mod fails logins even when the port answers) | always, when enabled |
+| **Routing integrity** | NAT table present · kill-switch table present (gateway mode) · bypass table present (bypass configured) | automatic, when the feature is configured |
+| **Egress data plane** | a real HTTPS fetch through each listed path — `direct` (main table), a **named gateway** (through its routing table), `default` (the subnet default gateway), or `all` | opt-in via `HEALTH_CHECK_EGRESS` |
+
+The probe never sleeps or retries internally — Docker's `--interval/--timeout/--retries` (60s/15s/3 baked in) govern cadence, so ≈3 minutes of consecutive failure flip the container to unhealthy. Its one-line output (`healthy: ocserv up (pid 399), 2 client(s); egress ok: direct,bal` or `unhealthy: <first failed check>`) is stored by Docker:
+
+```bash
+docker inspect --format '{{json .State.Health}}' ocserv-server | jq .
+```
+
+## Why gateway egress is opt-in
+
+On a cascade node, an upstream tunnel going down makes its users fail **closed** — worth alerting on, but marking the ocserv *container* unhealthy makes restart automation restart the wrong thing: restarting ocserv cannot fix an upstream and would drop every session. So the enabled default gates only on the server itself being sane; you explicitly list the egress paths whose failure you want to escalate to container health:
+
+```yaml
+- HEALTH_CHECK_EGRESS=direct           # only the node's own egress
+- HEALTH_CHECK_EGRESS=direct+bal+mt    # plus the gateways you'd act on
+- HEALTH_CHECK_EGRESS=all              # direct + default + every named gateway
+```
+
+For a gateway, every family it routes must pass (a dual-stack gateway with dead IPv6 is unhealthy); blocked families are skipped.
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `HEALTH_CHECK_ENABLED` | `false` | Master switch. The baked `HEALTHCHECK` always fires; when this is not `true` the probe reports healthy without checking anything. |
+| `HEALTH_CHECK_EGRESS` | _(unset)_ | Egress paths that gate health, joined with `+` (or `,`): `direct`, named gateways, `default`, `all`. Unset = no egress probing (tiers 1–2 only). An unknown name fails the probe loudly (config error). |
+| `HEALTH_CHECK_URL` | `https://1.1.1.1/cdn-cgi/trace` | URL(s) for the **direct** probe, `;`-separated, first success wins. Gateway probes always use the built-in IP-literal endpoint, since a hostname may resolve anywhere and cannot be pinned into the marking rules. |
+
+## Timeouts with many gateways
+
+Each gateway probe costs up to ~4 s worst-case, sequentially. The baked 15 s timeout comfortably covers tiers 1–2 plus `direct` and a couple of gateways; `all` with six gateways may exceed it. Either gate on the paths you would act on, or raise the timeout in your compose file (compose overrides the baked values without a rebuild):
+
+```yaml
+healthcheck:
+  timeout: 40s
+```
+
+## How it relates to `network-diagnostic`
+
+The health probe is the cheap, automated, binary answer; [`network-diagnostic`](Troubleshooting#first-moves) is the deep manual analysis. They share the same probe machinery but use **separate nft tables, fwmarks and rule priorities** (`ocserv_health`/`0xd1a7`/791 vs `ocserv_diag`/`0xd1a6`/790), so running the diagnostic while a health probe fires can never interfere. When the container goes unhealthy, `docker inspect` gives you the failing check, and `network-diagnostic` gives you the full picture.
+
+---
+
+Next: **[[Troubleshooting]]** · **[[Gateway Mode]]**

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -18,6 +18,7 @@ It speaks the OpenConnect/Cisco AnyConnect SSL-VPN protocol, so it works with th
 - **Per-user routing** — map each user to a different upstream gateway; hot-reloadable, no static IPs needed
 - **Destination bypass** — route by destination: country pools direct, chosen services via a specific exit, ad/malware pools blocked; lists auto-fetched and hot-reloaded
 - **Certificate hot-reload** — a renewed Let's Encrypt cert is picked up without a restart or dropped sessions
+- **Opt-in health monitor** — Docker-native `HEALTHCHECK`: server liveness, routing integrity, and (optionally) real egress probes per gateway
 - **Reverse-proxy friendly** — designed to share Let's Encrypt certificates with [SWAG](https://github.com/linuxserver/docker-swag)
 - **Multi-arch images** published to GHCR (and Docker Hub for releases)
 
@@ -36,6 +37,7 @@ It speaks the OpenConnect/Cisco AnyConnect SSL-VPN protocol, so it works with th
 | Understand NAT, routing, full vs split tunnel | **[[Networking NAT and Routing]]** |
 | Route clients out through another VPN (e.g. NordVPN) | **[[Gateway Mode]]** |
 | Route by destination — bypass pools, per-service exits, blocklists | **[[Destination Bypass]]** |
+| Report container health to Docker / monitoring | **[[Health Monitor]]** |
 | Connect a client or router | **[[Clients and Devices]]** |
 | See how the image is built internally | **[[Architecture and Internals]]** |
 | Fix a problem | **[[Troubleshooting]]** |

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -17,6 +17,7 @@
 - [[Networking NAT and Routing]]
 - [[Gateway Mode]]
 - [[Destination Bypass]]
+- [[Health Monitor]]
 - [[Clients and Devices]]
 
 **Under the hood**


### PR DESCRIPTION
Implements the reviewed design: an opt-in, Docker-native health probe in the openconnect-client pattern.

## Shape

```dockerfile
HEALTHCHECK --interval=60s --timeout=15s --start-period=60s --retries=3 CMD ["/usr/local/bin/healthcheck"]
```

The instruction always fires; the probe **reports healthy without checking anything unless `HEALTH_CHECK_ENABLED=true`** — zero cost and zero behaviour change for existing deployments. Side-effect-free: no sleeps, no internal retries, never touches vpngw state; Docker's interval/timeout/retries govern cadence, and the probe's one-line output lands in `.State.Health.Log` so `docker inspect` names the failing check.

## Health gates

| Tier | Checks | When |
|---|---|---|
| Server liveness | ocserv process · TCP listener on `tcp-port` · `occtl` responding | always when enabled |
| Routing integrity | NAT / kill-switch / bypass tables present when configured | automatic |
| Egress data plane | real HTTPS fetch per listed path: `direct`, named gateways, `default`, `all` | opt-in: `HEALTH_CHECK_EGRESS` |

Gateway gating is **opt-in on purpose** (documented on the new wiki page): an upstream outage should flip *container* health only when the operator would act on it — restart automation bouncing ocserv can't fix an upstream and would drop every session. `HEALTH_CHECK_URL` (`;`-list, first success) customizes the direct probe; gateway probes use the built-in IP-literal endpoint since hostnames can't be pinned into marking rules.

```yaml
environment:
  - HEALTH_CHECK_ENABLED=true
  - HEALTH_CHECK_EGRESS=direct+bal+mt
```

## Shared probe machinery

The egress-probe helpers moved from `network-diagnostic` into `backend-functions`, parameterized by table/mark/prio. The healthcheck uses its **own triple** (`ocserv_health`/`0xd1a7`/791) vs the diagnostic's (`ocserv_diag`/`0xd1a6`/790), so a manual diagnostic run can never collide with a firing probe. `network-diagnostic` now wraps the shared helpers — output byte-identical in the harness.

## Validation

Harness scenarios: disabled no-op (exit 0), tiers-only healthy, `direct+nl+default` egress, `all` expansion (direct+default+every gateway), unknown gateway → loud fail, dead ocserv → fail, broken direct egress → fail — plus full diagnostic regression after the refactor. shellcheck clean across all three scripts.

## Docs

New **[[Health Monitor]]** wiki page (restart caveat, timeout budget for many gateways, `docker inspect` usage, relation to network-diagnostic), Configuration Reference group + index row, README feature bullet + env table, sidebar/Home/Architecture entries.