### PR TITLE
docs: ocserv supports more than the AnyConnect protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ OpenConnect VPN server ([ocserv](https://ocserv.gitlab.io/www/)) in a small self
 
 ## ✨ Key Features
 
-- **🔐 OpenConnect / AnyConnect protocol** — works with the `openconnect` client, Cisco AnyConnect apps, and routers such as Keenetic / Netcraze, OpenWrt and GL.iNet ([details][wiki-clients])
+- **🔐 Broad client support** — everything ocserv supports (the image runs it unmodified): the `openconnect` client, Cisco AnyConnect / Secure Client, mobile apps, and routers such as Keenetic / Netcraze, OpenWrt and GL.iNet ([details][wiki-clients])
 - **🚀 Self-configuring networking** — NAT, forwarding and MSS clamping set up automatically with nftables; just mount a config and go ([details][wiki-network])
 - **🕵️ Camouflage mode** — to probes and DPI the server looks like an ordinary HTTPS website; only clients that know the secret reach the VPN ([details][wiki-camo])
 - **🚪 Gateway mode** — route clients out through upstream VPN containers (e.g. NordVPN) instead of the host's connection ([details][wiki-gateway])

--- a/wiki/Clients-and-Devices.md
+++ b/wiki/Clients-and-Devices.md
@@ -1,6 +1,6 @@
 # Clients and Devices
 
-ocserv speaks the OpenConnect / Cisco AnyConnect SSL-VPN protocol, so a wide range of clients work. The connection target is your server URL — **including the camouflage secret** if [camouflage](Camouflage-Mode) is enabled.
+This image runs **unmodified ocserv**, so every client and protocol ocserv itself supports works here — the sections below just cover the common ones. Most clients use the OpenConnect / AnyConnect-compatible mode, but the project is not limited to it: whatever your ocserv version accepts, the container accepts. The connection target is your server URL — **including the camouflage secret** if [camouflage](Camouflage-Mode) is enabled.
 
 > If camouflage is on, every example below must use `https://host:port/?your-secret` as the server URL. (On OpenWrt the LuCI server field may not accept a URL — use the `usergroup` option or edit the config file directly; see that section.)
 
@@ -83,7 +83,7 @@ config interface 'oc'
 	#option no_dtls '1'
 ```
 
-The protocol defaults to AnyConnect — exactly what ocserv speaks, so there is nothing else to set.
+The handler's protocol default (AnyConnect-compatible) is the right one for ocserv, so there is nothing else to set.
 
 > **Camouflage on OpenWrt:** the LuCI form's server field may not accept a full URL (`https://host:port/?your-secret`) — it expects a bare hostname. Two ways around it: keep a bare `option server` and carry the secret in **`option usergroup '?your-secret'`** (shown above, works everywhere), or edit `/etc/config/network` directly and put the full URL into `option server` — the config file itself is not restricted by the form validation, and the underlying `openconnect` client accepts a URL as the server.
 

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -1,7 +1,7 @@
 # FAQ
 
 **What protocol does this use? Which clients work?**
-The OpenConnect / Cisco AnyConnect SSL-VPN protocol. Works with the `openconnect` client, Cisco AnyConnect / Secure Client, mobile OpenConnect apps, and routers like Keenetic / Netcraze, OpenWrt and GL.iNet. See [[Clients and Devices]].
+Everything ocserv supports — the image runs unmodified ocserv, so it is not limited to one protocol. In practice most clients use the OpenConnect / AnyConnect-compatible mode: the `openconnect` client, Cisco AnyConnect / Secure Client, mobile OpenConnect apps, and routers like Keenetic / Netcraze, OpenWrt and GL.iNet. See [[Clients and Devices]].
 
 **Which image tag should I use?**
 `ghcr.io/azinchen/ocserv-server:dev` for the latest development build (the `main` branch), or `azinchen/ocserv-server:latest` / a pinned `:x.y.z` for releases. See [[Building and CI]].

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -4,7 +4,7 @@
 
 `ocserv-server` packages [ocserv](https://ocserv.gitlab.io/www/) — the OpenConnect VPN server — into a small, self-configuring Alpine-based container image. It builds ocserv from source, wires up NAT/forwarding automatically with **nftables**, and supervises the daemon with **s6-overlay** so the container behaves like a proper init system.
 
-It speaks the OpenConnect/Cisco AnyConnect SSL-VPN protocol, so it works with the `openconnect` client, the Cisco AnyConnect client, mobile clients, and routers such as Keenetic / Netcraze, OpenWrt and GL.iNet.
+It runs unmodified ocserv, so every client and protocol ocserv supports works here — commonly the `openconnect` client, Cisco AnyConnect / Secure Client, mobile OpenConnect apps, and routers such as Keenetic / Netcraze, OpenWrt and GL.iNet (typically via the AnyConnect-compatible mode).
 
 ---
 


### PR DESCRIPTION
The docs claimed the project "speaks the OpenConnect / Cisco AnyConnect SSL-VPN protocol" — too narrow. The image runs **unmodified ocserv**, so it supports every client and protocol ocserv itself supports; the AnyConnect-compatible mode is the common case (it's what Keenetic/Netcraze, OpenWrt and most clients use), not a project limitation.

Reworded in five places:
- README **Broad client support** feature bullet (was "OpenConnect / AnyConnect protocol")
- wiki **Home** intro
- wiki **FAQ** "What protocol does this use?" answer
- wiki **Clients and Devices** intro ("every client and protocol ocserv itself supports works here — the sections below just cover the common ones")
- the OpenWrt note ("the handler's protocol default (AnyConnect-compatible) is the right one for ocserv")

No code changes.