### PR TITLE
diag: informational pool age, trimmed occtl status; fetch catch-up at startup

### DIFF
--- a/rootfs/etc/s6-overlay/s6-rc.d/svc-bypass-fetch/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/svc-bypass-fetch/run
@@ -5,8 +5,11 @@
 # VPN_BYPASS_UPDATE_INTERVAL>0 and VPN_BYPASS_SOURCES_FILE is set, run
 # bypass-fetch on that interval so published country/feed lists stay current
 # without an external process. At startup, pools whose list file is MISSING
-# are fetched immediately (first boot with an empty volume); existing files
-# are trusted until the first interval elapses.
+# are fetched immediately (first boot with an empty volume), and so are pools
+# whose last successful fetch (.<pool>.stamp, falling back to the list's
+# mtime) is already older than the interval - without that catch-up, a
+# container restarted more often than the interval would NEVER refetch,
+# because the loop below sleeps a full interval before its first run.
 #
 # When fetching is disabled (or nothing to fetch) the service idles, so it can
 # stay in the s6 user bundle unconditionally.
@@ -27,13 +30,21 @@ if [ ! -f "$vpngw_state_dir/bypass_pools" ]; then
     exec sleep infinity
 fi
 
+now="$(date +%s)"
 missing=""
 while read -r p; do
     [ -n "$p" ] || continue
-    [ -f "$vpn_bypass_pools_dir/$p.list" ] || missing="$missing $p"
+    if [ ! -f "$vpn_bypass_pools_dir/$p.list" ]; then
+        missing="$missing $p"
+        continue
+    fi
+    ref="$vpn_bypass_pools_dir/.$p.stamp"
+    [ -f "$ref" ] || ref="$vpn_bypass_pools_dir/$p.list"
+    mtime="$(stat -c %Y "$ref" 2>/dev/null || echo 0)"
+    [ $((now - mtime)) -ge "$vpn_bypass_update_interval" ] && missing="$missing $p"
 done < "$vpngw_state_dir/bypass_pools"
 if [ -n "$missing" ]; then
-    log "[BYPASS-FETCH] Fetching pools with no published list yet:$missing"
+    log "[BYPASS-FETCH] Fetching pools with no or outdated published list:$missing"
     # shellcheck disable=SC2086
     /usr/local/bin/bypass-fetch $missing \
         || log_error "[BYPASS-FETCH] Warning: initial fetch failed; will retry on the interval"

--- a/rootfs/usr/local/bin/network-diagnostic
+++ b/rootfs/usr/local/bin/network-diagnostic
@@ -634,8 +634,17 @@ echo "Server status             : $SERVER_STATE"
 echo "Connected clients         : $CONNECTED"
 echo
 
-section "occtl show status"
-occtl_show show status
+# Only the "General info" block: the "Current stats period" counters that
+# follow are ocserv-internal aggregates since the last stats reset (sessions
+# closed due to error, RX/TX updated only on disconnect, ...) - without that
+# context they read as live problems. session-report is the place for
+# per-session detail.
+section "occtl status (general info)"
+_ocs="$(occtl_show show status)"
+case "$_ocs" in
+    *"General info:"*) printf '%s\n' "$_ocs" | awk '/^General info:/ { f = 1 } /^Current stats period:/ { exit } f' ;;
+    *) printf '%s\n' "$_ocs" ;;
+esac
 echo
 
 section "Listening sockets"
@@ -1004,32 +1013,18 @@ if [ -f "$vpngw_state_dir/bypass_pools" ]; then
         if [ -f "$_lf" ]; then
             _age="$(file_age "$_lf")"
             _lfs="$(wc -l < "$_lf") lines ($(age_fmt "${_age:-0}") old)"
-            # Freshness = last SUCCESSFUL fetch, not the list's mtime: the
-            # fetcher deliberately skips republishing an unchanged list, so a
-            # stable upstream keeps the mtime old while fetches succeed daily.
-            # It stamps .<pool>.stamp on every success; fall back to the
-            # list's mtime when no stamp exists (external publisher, or
-            # fetching never ran).
+            # The fetcher skips republishing an unchanged list but stamps
+            # .<pool>.stamp on every successful fetch - show that too. Age
+            # alone is informational (a list may simply not change; a restart
+            # postpones the next cycle), so it never warns.
             _fage="$(file_age "$vpn_bypass_pools_dir/.$_p.stamp")"
-            if [ -n "$_fage" ]; then
-                _lfs="$_lfs, fetched $(age_fmt "$_fage") ago"
-            else
-                _fage="$_age"
-            fi
-            # Freshness vs the fetcher interval (allow one missed run)
-            if [ -n "$vpn_bypass_sources_file" ] && [ "${vpn_bypass_update_interval:-0}" -gt 0 ] 2>/dev/null \
-                && [ -n "$_fage" ] && [ "$_fage" -gt $((vpn_bypass_update_interval * 2)) ] \
-                && grep -q "^[[:space:]]*${_p}[[:space:]]" "$vpn_bypass_sources_file" 2>/dev/null; then
-                _stale_pools="${_stale_pools:-} $_p($(age_fmt "$_fage"))"
-            fi
+            [ -n "$_fage" ] && _lfs="$_lfs, fetched $(age_fmt "$_fage") ago"
         else
             _lfs="MISSING (empty pool)"
         fi
         printf '%-14s %-10s %-6s %-22s %-14s %s\n' "$_p" "$_t" "$_m" \
             "$_n4 + $_n6 intervals" "$_sub" "$_lfs"
     done < "$vpngw_state_dir/bypass_targets"
-    [ -n "${_stale_pools:-}" ] \
-        && warn "pool(s) without a successful fetch for over 2x VPN_BYPASS_UPDATE_INTERVAL:${_stale_pools} - check bypass-fetch (docker logs, grep BYPASS-FETCH)"
 
     # Probe each distinct bypass target through its LIVE fwmark rule: proves
     # the prio-800 policy rules and the target's routing table end to end.

--- a/wiki/Destination-Bypass.md
+++ b/wiki/Destination-Bypass.md
@@ -163,8 +163,8 @@ Sources must serve **plain CIDR-per-line** text (ipdeny.com zone files, country-
 
 - a source that can't be fetched — or yields not a single valid CIDR (an HTML error page, a truncated download) — is **ignored with a warning**; the pool is built from the remaining sources;
 - if **every** source of a pool fails, the published list is left untouched (last-known-good);
-- published lists live on the volume, so restarts work offline; at startup only pools with **no published list yet** are fetched immediately (a first boot with an empty volume comes up populated), existing lists are trusted until the interval elapses;
-- every successful fetch touches a `.<pool>.stamp` marker next to the list (the list itself is only rewritten when its content changed). `network-diagnostic` judges freshness by the stamp, so a stable upstream list never looks stale — a stale-pool warning means fetching itself has been failing.
+- published lists live on the volume, so restarts work offline; at startup, pools with **no published list yet** are fetched immediately (a first boot with an empty volume comes up populated), and so are pools whose last successful fetch is already **older than the interval** — so frequent container restarts can't postpone refreshes indefinitely;
+- every successful fetch touches a `.<pool>.stamp` marker next to the list (the list itself is only rewritten when its content changed). `network-diagnostic` shows both ages: `10808 lines (3d old), fetched 2h ago` means the upstream list simply hasn't changed in 3 days while fetching works fine.
 
 Force a refresh any time:
 


### PR DESCRIPTION
- The stale-pool warning is gone: list age is informational (a stable
  upstream list simply does not change; a restart postpones the next
  cycle) and it kept pushing the exit code to 1 on healthy nodes. The
  table still shows both ages: '10808 lines (3d old), fetched 2h ago'.

- The real reason lists went stale: svc-bypass-fetch sleeps a full
  interval before its first run, so a container restarted more often
  than the interval NEVER refetched. At startup it now also fetches
  pools whose last successful fetch (.<pool>.stamp, falling back to
  the list mtime) is already older than the interval.

- The occtl status dump is trimmed to the 'General info' block. The
  'Current stats period' counters (sessions closed due to error, RX/TX
  updated only on disconnect) are ocserv-internal aggregates that read
  as live problems without context; per-session detail belongs to the
  upcoming session-report.
