### PR TITLE
Session accounting: who connected when, and how much data took which path

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ OpenConnect VPN server ([ocserv](https://ocserv.gitlab.io/www/)) in a small self
 - **🛡️ Fail-closed kill switch** — nftables next-hop guards on every routed path: if an upstream is down, clients lose internet rather than leak ([details][wiki-killswitch])
 - **🔄 Hot-reload everything** — user maps, pool lists, DNS-named gateway addresses and TLS certificates all reload live, without dropping sessions ([details][wiki-reload])
 - **🔒 Reverse-proxy & Let's Encrypt friendly** — share SWAG's certificates; renewals are picked up without a restart ([details][wiki-certs])
+- **📊 Session accounting** — `session-report` shows every session's connect/disconnect times and its traffic split per gateway and bypass pool ([details][wiki-sessions])
 - **🩺 Opt-in health monitor** — Docker-native `HEALTHCHECK`: server liveness, routing integrity, and (optionally) real egress probes per gateway ([details][wiki-health])
 - **📵 IPv6 without leaks** — optional NAT66; when an upstream has no IPv6, client IPv6 is rejected fail-closed instead of escaping ([details][wiki-ipv6])
 - **📦 Multi-arch, from source** — amd64 / arm64 / riscv64 images, ocserv built from source, supervised by s6-overlay
@@ -229,6 +230,7 @@ MIT — see [LICENSE](LICENSE).
 [wiki-ipv6]: https://github.com/azinchen/ocserv-server/wiki/Networking-NAT-and-Routing#ipv6
 [wiki-certs]: https://github.com/azinchen/ocserv-server/wiki/Reverse-Proxy-and-Certificates
 [wiki-health]: https://github.com/azinchen/ocserv-server/wiki/Health-Monitor
+[wiki-sessions]: https://github.com/azinchen/ocserv-server/wiki/Session-Accounting
 [wiki-clients]: https://github.com/azinchen/ocserv-server/wiki/Clients-and-Devices
 [wiki-troubleshoot]: https://github.com/azinchen/ocserv-server/wiki/Troubleshooting
 [wiki-faq]: https://github.com/azinchen/ocserv-server/wiki/FAQ

--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ Grouped by feature; every variable is one line here — the **[Configuration Ref
 | `VPN_BYPASS_RULE_PRIO` | `800` | Priority of the bypass policy rules (advanced). |
 | `VPN_BYPASS_MARK` | `0xbc` | Base fwmark for bypassed traffic (advanced). |
 
+### Session accounting — [details][wiki-sessions]
+
+| Variable | Default | Description |
+|---|---|---|
+| `SESSION_HISTORY_FILE` | _(unset)_ | Persist completed-session history on a volume (default: tmpfs, container lifetime). |
+
 ### Health monitor — [details][wiki-health]
 
 | Variable | Default | Description |

--- a/rootfs/etc/s6-overlay/s6-rc.d/init-vpngw/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/init-vpngw/run
@@ -71,6 +71,9 @@ if [ "$gw_active" = 0 ]; then
 fi
 
 mkdir -p "$vpngw_state_dir"
+# Collection horizon marker for session-report: the state dir is tmpfs, so
+# session history covers this container start.
+date +%s > "$vpngw_state_dir/started"
 
 table="$vpn_gateway_table"
 prio="$vpn_gateway_rule_prio"

--- a/rootfs/usr/local/bin/backend-functions
+++ b/rootfs/usr/local/bin/backend-functions
@@ -52,6 +52,7 @@ cert_watch_interval="${CERT_WATCH_INTERVAL:-0}"
 health_check_enabled="${HEALTH_CHECK_ENABLED:-false}"
 health_check_egress="${HEALTH_CHECK_EGRESS:-}"
 health_check_url="${HEALTH_CHECK_URL:-https://1.1.1.1/cdn-cgi/trace}"
+session_history_file="${SESSION_HISTORY_FILE:-}"
 ocserv_config="${OCSERV_CONFIG:-/etc/ocserv/ocserv.conf}"
 
 # Normalise the subnet-default gateway values (unmapped users). Each family
@@ -551,26 +552,41 @@ acct_apply_session() {
     _ac_t="$(acct_table)"
     acct_ensure_base "$_ac_t" || return 1
     _ac_s="$(acct_sid "$_ac_ip4")"
+    # A destination can sit in several of the session's pools; routing gives
+    # it to the FIRST matching pool (marking-rule order = bypass_pools file
+    # order). The counters must mirror that or overlapping pools would be
+    # double-counted and over-subtracted from the gateway share: totals are
+    # counted first, then one block per pool in the same order, each ending
+    # the walk with return on match.
+    if [ $# -gt 0 ] && [ -f "$vpngw_state_dir/bypass_pools" ]; then
+        _ac_ordered=""
+        while read -r _ac_bp; do
+            for _ac_p in "$@"; do
+                [ "$_ac_p" = "$_ac_bp" ] && _ac_ordered="$_ac_ordered $_ac_p"
+            done
+        done < "$vpngw_state_dir/bypass_pools"
+        # shellcheck disable=SC2086
+        set -- $_ac_ordered
+    fi
     _ac_counters=""
-    _ac_rules=""
+    _ac_rules="
+        ip saddr $_ac_ip4 counter name a_${_ac_s}_up
+        ip daddr $_ac_ip4 counter name a_${_ac_s}_dn"
+    [ -n "$_ac_ip6" ] && _ac_rules="$_ac_rules
+        ip6 saddr $_ac_ip6 counter name a_${_ac_s}_up
+        ip6 daddr $_ac_ip6 counter name a_${_ac_s}_dn"
     for _ac_p in "$@"; do
         _ac_pi="$(acct_pool_id "$_ac_p")"
         _ac_counters="$_ac_counters
     counter a_${_ac_s}_${_ac_pi}_up { packets 0 bytes 0 }
     counter a_${_ac_s}_${_ac_pi}_dn { packets 0 bytes 0 }"
         _ac_rules="$_ac_rules
-        ip saddr $_ac_ip4 ip daddr @pool_${_ac_p}_v4 counter name a_${_ac_s}_${_ac_pi}_up
-        ip saddr @pool_${_ac_p}_v4 ip daddr $_ac_ip4 counter name a_${_ac_s}_${_ac_pi}_dn"
+        ip saddr $_ac_ip4 ip daddr @pool_${_ac_p}_v4 counter name a_${_ac_s}_${_ac_pi}_up return
+        ip saddr @pool_${_ac_p}_v4 ip daddr $_ac_ip4 counter name a_${_ac_s}_${_ac_pi}_dn return"
         [ -n "$_ac_ip6" ] && _ac_rules="$_ac_rules
-        ip6 saddr $_ac_ip6 ip6 daddr @pool_${_ac_p}_v6 counter name a_${_ac_s}_${_ac_pi}_up
-        ip6 saddr @pool_${_ac_p}_v6 ip6 daddr $_ac_ip6 counter name a_${_ac_s}_${_ac_pi}_dn"
+        ip6 saddr $_ac_ip6 ip6 daddr @pool_${_ac_p}_v6 counter name a_${_ac_s}_${_ac_pi}_up return
+        ip6 saddr @pool_${_ac_p}_v6 ip6 daddr $_ac_ip6 counter name a_${_ac_s}_${_ac_pi}_dn return"
     done
-    _ac_rules="$_ac_rules
-        ip saddr $_ac_ip4 counter name a_${_ac_s}_up
-        ip daddr $_ac_ip4 counter name a_${_ac_s}_dn"
-    [ -n "$_ac_ip6" ] && _ac_rules="$_ac_rules
-        ip6 saddr $_ac_ip6 counter name a_${_ac_s}_up
-        ip6 daddr $_ac_ip6 counter name a_${_ac_s}_dn"
     nft -f - <<EOF || return 1
 table inet $_ac_t {$_ac_counters
     counter a_${_ac_s}_up { packets 0 bytes 0 }
@@ -616,6 +632,13 @@ acct_cleanup_session() {
 acct_counter_bytes() { # $1 = table, $2 = counter name -> bytes (empty if absent)
     nft list counter inet "$1" "$2" 2>/dev/null \
         | sed -n 's/.*packets [0-9]* bytes \([0-9]*\).*/\1/p' | head -1
+}
+
+# Completed sessions land here, one line per session. SESSION_HISTORY_FILE
+# (e.g. a path on the config volume) makes the history persist across
+# container recreations; the default is tmpfs, i.e. container lifetime.
+acct_history_file() {
+    echo "${session_history_file:-$vpngw_state_dir/history}"
 }
 
 # Remove every policy rule and kill-switch entry for a session's addresses.

--- a/rootfs/usr/local/bin/backend-functions
+++ b/rootfs/usr/local/bin/backend-functions
@@ -489,6 +489,135 @@ bypass_apply_session() {
     return 0
 }
 
+# ---- Per-session traffic accounting ------------------------------------------
+# Named nft counters per session (totals + one pair per attached bypass pool),
+# read live by session-report and snapshotted into the history file by the
+# disconnect hook. The counters count FORWARDED tunnel traffic: "up" is
+# client -> world, "down" is world -> client; traffic terminating in the
+# container (tunneled DNS, probes) and traffic later dropped by the kill
+# switch is not split per path - ocserv's own totals cover the difference.
+#
+# Everything lives in ONE table: alongside the pool sets in inet ocserv_bypass
+# when destination bypass is configured (per-pool rules reference @pool_* sets,
+# and nft cannot reference sets across tables), else in inet ocserv_gw. Both
+# are safe at runtime: only init-vpngw recreates them; the gw-resolver flushes
+# just the forward chain. A dispatch chain sends each direction through the
+# session's own counter chain via verdict maps, so connect/disconnect never
+# has to delete rules by handle - elements and chains are keyed by address.
+#
+# Accounting is best-effort by design: a session that cannot be counted must
+# still connect, so callers ignore these return values.
+
+acct_table() {
+    if [ -f "$vpngw_state_dir/bypass_pools" ]; then
+        echo ocserv_bypass
+    else
+        echo ocserv_gw
+    fi
+}
+
+acct_sid() { echo "$1" | tr '.' '_'; }
+# Pool names may contain '-', nft object names may not: sanitize. (Two pools
+# differing only in '-' vs '_' would collide; init-vpngw's name rules make
+# that a non-issue in practice.)
+acct_pool_id() { echo "$1" | tr '-' '_'; }
+
+acct_ensure_base() { # $1 = table
+    nft list chain inet "$1" acct >/dev/null 2>&1 && return 0
+    nft -f - <<EOF
+table inet $1 {
+    map acct_src4 { type ipv4_addr : verdict; }
+    map acct_dst4 { type ipv4_addr : verdict; }
+    map acct_src6 { type ipv6_addr : verdict; }
+    map acct_dst6 { type ipv6_addr : verdict; }
+    chain acct {
+        type filter hook forward priority filter - 30; policy accept;
+        ip saddr vmap @acct_src4
+        ip daddr vmap @acct_dst4
+        ip6 saddr vmap @acct_src6
+        ip6 daddr vmap @acct_dst6
+    }
+}
+EOF
+}
+
+# Install a session's counters and dispatch entries.
+#   $1 = IPv4   $2 = IPv6 (may be empty)   $3... = bypass pool names
+acct_apply_session() {
+    _ac_ip4="$1"
+    _ac_ip6="$2"
+    shift 2
+    [ -n "$_ac_ip4" ] || return 0
+    _ac_t="$(acct_table)"
+    acct_ensure_base "$_ac_t" || return 1
+    _ac_s="$(acct_sid "$_ac_ip4")"
+    _ac_counters=""
+    _ac_rules=""
+    for _ac_p in "$@"; do
+        _ac_pi="$(acct_pool_id "$_ac_p")"
+        _ac_counters="$_ac_counters
+    counter a_${_ac_s}_${_ac_pi}_up { packets 0 bytes 0 }
+    counter a_${_ac_s}_${_ac_pi}_dn { packets 0 bytes 0 }"
+        _ac_rules="$_ac_rules
+        ip saddr $_ac_ip4 ip daddr @pool_${_ac_p}_v4 counter name a_${_ac_s}_${_ac_pi}_up
+        ip saddr @pool_${_ac_p}_v4 ip daddr $_ac_ip4 counter name a_${_ac_s}_${_ac_pi}_dn"
+        [ -n "$_ac_ip6" ] && _ac_rules="$_ac_rules
+        ip6 saddr $_ac_ip6 ip6 daddr @pool_${_ac_p}_v6 counter name a_${_ac_s}_${_ac_pi}_up
+        ip6 saddr @pool_${_ac_p}_v6 ip6 daddr $_ac_ip6 counter name a_${_ac_s}_${_ac_pi}_dn"
+    done
+    _ac_rules="$_ac_rules
+        ip saddr $_ac_ip4 counter name a_${_ac_s}_up
+        ip daddr $_ac_ip4 counter name a_${_ac_s}_dn"
+    [ -n "$_ac_ip6" ] && _ac_rules="$_ac_rules
+        ip6 saddr $_ac_ip6 counter name a_${_ac_s}_up
+        ip6 daddr $_ac_ip6 counter name a_${_ac_s}_dn"
+    nft -f - <<EOF || return 1
+table inet $_ac_t {$_ac_counters
+    counter a_${_ac_s}_up { packets 0 bytes 0 }
+    counter a_${_ac_s}_dn { packets 0 bytes 0 }
+    chain acct_${_ac_s} {$_ac_rules
+    }
+}
+EOF
+    nft add element inet "$_ac_t" acct_src4 "{ $_ac_ip4 : jump acct_${_ac_s} }" || return 1
+    nft add element inet "$_ac_t" acct_dst4 "{ $_ac_ip4 : jump acct_${_ac_s} }" || return 1
+    if [ -n "$_ac_ip6" ]; then
+        nft add element inet "$_ac_t" acct_src6 "{ $_ac_ip6 : jump acct_${_ac_s} }" 2>/dev/null || true
+        nft add element inet "$_ac_t" acct_dst6 "{ $_ac_ip6 : jump acct_${_ac_s} }" 2>/dev/null || true
+    fi
+    return 0
+}
+
+# Remove a session's dispatch entries, chain and counters. Idempotent.
+#   $1 = IPv4 (may be empty)   $2 = IPv6 (may be empty)
+acct_cleanup_session() {
+    _ac_ip4="${1:-}"
+    _ac_ip6="${2:-}"
+    [ -n "$_ac_ip4" ] || return 0
+    _ac_t="$(acct_table)"
+    _ac_s="$(acct_sid "$_ac_ip4")"
+    nft delete element inet "$_ac_t" acct_src4 "{ $_ac_ip4 }" 2>/dev/null || true
+    nft delete element inet "$_ac_t" acct_dst4 "{ $_ac_ip4 }" 2>/dev/null || true
+    if [ -n "$_ac_ip6" ]; then
+        nft delete element inet "$_ac_t" acct_src6 "{ $_ac_ip6 }" 2>/dev/null || true
+        nft delete element inet "$_ac_t" acct_dst6 "{ $_ac_ip6 }" 2>/dev/null || true
+    fi
+    nft flush chain inet "$_ac_t" "acct_${_ac_s}" 2>/dev/null || true
+    nft delete chain inet "$_ac_t" "acct_${_ac_s}" 2>/dev/null || true
+    # Counter names embed the pool list at connect time, which may since have
+    # changed - enumerate instead of guessing.
+    for _ac_c in $(nft list counters table inet "$_ac_t" 2>/dev/null \
+        | sed -n "s/^[[:space:]]*counter \(a_${_ac_s}_[A-Za-z0-9_]*\) {.*/\1/p"); do
+        nft delete counter inet "$_ac_t" "$_ac_c" 2>/dev/null || true
+    done
+    return 0
+}
+
+acct_counter_bytes() { # $1 = table, $2 = counter name -> bytes (empty if absent)
+    nft list counter inet "$1" "$2" 2>/dev/null \
+        | sed -n 's/.*packets [0-9]* bytes \([0-9]*\).*/\1/p' | head -1
+}
+
 # Remove every policy rule and kill-switch entry for a session's addresses.
 # Idempotent; used on disconnect, before (re)applying a session, and by reload.
 #   $1 = IPv4 (may be empty)   $2 = IPv6 (may be empty)

--- a/rootfs/usr/local/bin/ocserv-vpngw-script
+++ b/rootfs/usr/local/bin/ocserv-vpngw-script
@@ -142,7 +142,8 @@ case "$reason" in
                         "$h_client" "${h_gw:--}" "$h_dev" \
                         "${h_up:--}" "${h_dn:--}" \
                         "${STATS_BYTES_IN:--}" "${STATS_BYTES_OUT:--}" \
-                        "${h_pools:--}" >> "$vpngw_state_dir/history"
+                        "${h_pools:--}" >> "$(acct_history_file)" 2>/dev/null \
+                        || log_error "[VPNGW-HOOK] Warning: cannot append to $(acct_history_file)"
                 fi
             fi
             [ -n "$ip4" ] && vpngw_cleanup_session "$ip4" "$ip6"

--- a/rootfs/usr/local/bin/ocserv-vpngw-script
+++ b/rootfs/usr/local/bin/ocserv-vpngw-script
@@ -93,6 +93,18 @@ case "$reason" in
                 printf '%s %s %s %s %s\n' \
                     "$username" "${gwname:--}" "$ip4" "${ip6:--}" "${bp_rec:--}" > "$sess_file"
             fi
+            # Traffic accounting (session-report): per-session counters plus
+            # a connect record. Best-effort - a session that cannot be
+            # counted still connects.
+            if [ -n "$ip4" ]; then
+                acct_cleanup_session "$ip4" "$ip6"
+                # shellcheck disable=SC2086
+                acct_apply_session "$ip4" "$ip6" $bypass_pools \
+                    || log_error "[VPNGW-HOOK] Warning: no traffic counters for $ip4 (session-report will show '-')"
+                mkdir -p "$vpngw_state_dir/acct"
+                printf '%s %s %s\n' "$(date +%s)" "${IP_REAL:--}" "${DEVICE:--}" \
+                    > "$vpngw_state_dir/acct/$ip4"
+            fi
         ) 9>"$lock"; then
             log_error "[VPNGW-HOOK] Failed to route user '$username' (ip $ip4); rejecting session"
             exit 1
@@ -103,7 +115,39 @@ case "$reason" in
     disconnect)
         (
             flock 9
+            # Snapshot the session's counters into the history file BEFORE
+            # tearing anything down. ocserv hands us its own totals in the
+            # environment (STATS_BYTES_IN = from the client, STATS_BYTES_OUT
+            # = to the client); the nft counters add the per-path split.
+            if [ -n "$ip4" ] && [ -f "$sess_file" ]; then
+                read -r h_user h_gw _ h_ip6 h_bp < "$sess_file" || h_user=""
+                if [ -n "$h_user" ]; then
+                    h_t="$(acct_table)"
+                    h_s="$(acct_sid "$ip4")"
+                    h_conn="-"; h_client="-"; h_dev="-"
+                    [ -f "$vpngw_state_dir/acct/$ip4" ] \
+                        && read -r h_conn h_client h_dev < "$vpngw_state_dir/acct/$ip4"
+                    h_up="$(acct_counter_bytes "$h_t" "a_${h_s}_up")"
+                    h_dn="$(acct_counter_bytes "$h_t" "a_${h_s}_dn")"
+                    h_pools=""
+                    for h_p in $(printf '%s' "$h_bp" | tr '+' ' '); do
+                        [ "$h_p" = "-" ] && continue
+                        h_pi="$(acct_pool_id "$h_p")"
+                        h_pu="$(acct_counter_bytes "$h_t" "a_${h_s}_${h_pi}_up")"
+                        h_pd="$(acct_counter_bytes "$h_t" "a_${h_s}_${h_pi}_dn")"
+                        h_pools="${h_pools:+$h_pools,}$h_p=${h_pu:-0}:${h_pd:-0}"
+                    done
+                    printf '%s %s %s %s %s %s %s %s %s %s %s %s %s\n' \
+                        "$h_conn" "$(date +%s)" "$h_user" "$ip4" "${h_ip6:--}" \
+                        "$h_client" "${h_gw:--}" "$h_dev" \
+                        "${h_up:--}" "${h_dn:--}" \
+                        "${STATS_BYTES_IN:--}" "${STATS_BYTES_OUT:--}" \
+                        "${h_pools:--}" >> "$vpngw_state_dir/history"
+                fi
+            fi
             [ -n "$ip4" ] && vpngw_cleanup_session "$ip4" "$ip6"
+            [ -n "$ip4" ] && acct_cleanup_session "$ip4" "$ip6"
+            [ -n "$ip4" ] && rm -f "$vpngw_state_dir/acct/$ip4"
             [ -n "$sess_file" ] && rm -f "$sess_file"
         ) 9>"$lock"
         log "[VPNGW-HOOK] User '$username' ($ip4${ip6:+, $ip6}) gateway rules removed"

--- a/rootfs/usr/local/bin/session-report
+++ b/rootfs/usr/local/bin/session-report
@@ -3,40 +3,60 @@
 #
 # session-report - who connected, when, and how much data went where.
 #
-# Active sessions first, then completed ones (newest first). Each session
-# shows its traffic split: how much went through the user's gateway and how
-# much through each attached bypass pool. Data is collected by the ocserv
-# connect/disconnect hook (per-session nft counters + a history record on
-# disconnect), so the report needs gateway mode with a per-user map - exactly
-# the deployments where "which path did the bytes take" is a question.
+# Active sessions first (with live throughput sampled over one second), then
+# completed ones (newest first). Each session shows its traffic split: how
+# much went through the user's gateway and how much through each attached
+# bypass pool. Client IPs are geolocated (city/provider) when the network
+# allows. Ends with per-user totals and a reconnect-loop check.
 #
-# The horizon is CONTAINER start: state lives on tmpfs /run, sessions cannot
-# outlive the container anyway, and an ocserv-only restart inside a running
-# container keeps the history.
+# Data is collected by the ocserv connect/disconnect hook (per-session nft
+# counters + a history record on disconnect), so the report needs gateway
+# mode with a per-user map. History lives on tmpfs by default (container
+# lifetime); set SESSION_HISTORY_FILE to a path on a volume to persist it.
 #
 # "up" is client -> world, "down" is world -> client, counted on the forward
-# path. ocserv's own session totals (shown for completed sessions) also
-# include traffic terminating in the container, e.g. tunneled DNS - a small
-# constant gap between the two is normal.
+# path. ocserv's own totals (completed sessions) also include traffic
+# terminating in the container (e.g. tunneled DNS) - a small gap is normal.
 #
-# Usage: session-report [-u|--user NAME] [-h|--help]
+# Usage: session-report [options]
+#   -u, --user NAME   only this user
+#   -j, --json        machine-readable output
+#       --no-geo      skip client IP geolocation (faster offline)
+#       --no-rate     skip the 1s throughput sampling of active sessions
+#   -h, --help        this help
 
 set -u
 
 USER_FILTER=""
+MODE=text
+DO_GEO=1
+DO_RATE=1
 while [ $# -gt 0 ]; do
     case "$1" in
         -u|--user) USER_FILTER="${2:-}"; shift ;;
-        -h|--help)
-            sed -n '3,22s/^# \{0,1\}//p' "$0"
-            exit 0
-            ;;
+        -j|--json) MODE=json ;;
+        --no-geo)  DO_GEO=0 ;;
+        --no-rate) DO_RATE=0 ;;
+        -h|--help) sed -n '4,26s/^# \{0,1\}//p' "$0"; exit 0 ;;
         *) echo "Unknown option: $1" >&2; exit 2 ;;
     esac
     shift
 done
 
 . /usr/local/bin/backend-functions
+
+# Reconnect-loop check: this many completed sessions shorter than FLAP_SHORT
+# seconds within the last FLAP_WINDOW seconds flags the user.
+FLAP_WINDOW=3600
+FLAP_SHORT=120
+FLAP_MIN=3
+
+TMP_BASE="/tmp/session-report.$$"
+SUMMARY="$TMP_BASE.sum"
+GEO_CACHE="$TMP_BASE.geo"
+RATE_SNAP="$TMP_BASE.rate"
+: > "$SUMMARY"
+trap 'rm -f "$SUMMARY" "$GEO_CACHE" "$RATE_SNAP"' EXIT INT TERM
 
 hr() { echo "================================================================"; }
 
@@ -65,15 +85,53 @@ dur_fmt() { # seconds -> 45s / 12m30s / 3h07m / 2d05h
         else printf "%ds", s }'
 }
 
+json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+
+json_num() { # number or JSON null for "-"/empty
+    case "$1" in ''|-|*[!0-9]*) echo null ;; *) echo "$1" ;; esac
+}
+
+json_str() { # quoted string or JSON null for "-"/empty
+    case "$1" in ''|-) echo null ;; *) echo "\"$(json_escape "$1")\"" ;; esac
+}
+
 pool_target() { # $1 = pool -> its target (direct if unknown)
     awk -v p="$1" '$1 == p { print $2; exit }' \
         "$vpngw_state_dir/bypass_targets" 2>/dev/null | grep . || echo direct
 }
 
-# Print the per-path breakdown lines for one session.
-#   $1 = gateway ("-" = default/unmapped, "direct")
-#   $2 = total up bytes (or "-")   $3 = total down bytes (or "-")
-#   $4 = "pool=up:dn,..." (or "-")
+geo_of() { # $1 = ip -> "City, CC - org" (empty on failure; cached per run)
+    [ "$DO_GEO" = 1 ] || return 0
+    case "$1" in ''|-) return 0 ;; esac
+    _g_hit="$(awk -v ip="$1" '$1 == ip { $1 = ""; sub(/^ /, ""); print; exit }' "$GEO_CACHE" 2>/dev/null)"
+    if [ -n "$_g_hit" ]; then
+        [ "$_g_hit" = "-" ] || printf '%s\n' "$_g_hit"
+        return 0
+    fi
+    _g_city=""; _g_cc=""; _g_org=""
+    _g_resp="$(wget -q -T 4 -O - "https://ipinfo.io/$1/json" 2>/dev/null)" || _g_resp=""
+    if [ -n "$_g_resp" ]; then
+        _g_city="$(printf '%s\n' "$_g_resp" | sed -n 's/.*"city"[: ]*"\([^"]*\)".*/\1/p' | head -1)"
+        _g_cc="$(printf '%s\n' "$_g_resp" | sed -n 's/.*"country"[: ]*"\([^"]*\)".*/\1/p' | head -1)"
+        _g_org="$(printf '%s\n' "$_g_resp" | sed -n 's/.*"org"[: ]*"\([^"]*\)".*/\1/p' | head -1)"
+    fi
+    if [ -z "$_g_city$_g_cc" ]; then
+        _g_resp="$(wget -q -T 4 -O - "http://ip-api.com/line/$1?fields=city,countryCode,isp" 2>/dev/null)" || _g_resp=""
+        _g_city="$(printf '%s\n' "$_g_resp" | sed -n 1p)"
+        _g_cc="$(printf '%s\n' "$_g_resp" | sed -n 2p)"
+        _g_org="$(printf '%s\n' "$_g_resp" | sed -n 3p)"
+    fi
+    _g_out=""
+    [ -n "$_g_city" ] && _g_out="$_g_city"
+    [ -n "$_g_cc" ] && _g_out="${_g_out:+$_g_out, }$_g_cc"
+    [ -n "$_g_org" ] && _g_out="${_g_out:+$_g_out - }$_g_org"
+    echo "$1 ${_g_out:--}" >> "$GEO_CACHE"
+    [ -n "$_g_out" ] && printf '%s\n' "$_g_out"
+    return 0
+}
+
+# Per-path breakdown lines (text mode).
+#   $1 = gateway   $2 = total up   $3 = total down   $4 = "pool=up:dn,..."
 breakdown() {
     _bk_gw="$1"; _bk_up="$2"; _bk_dn="$3"; _bk_pools="$4"
     [ "$_bk_up" = "-" ] && [ "$_bk_pools" = "-" ] && return 0
@@ -99,42 +157,32 @@ breakdown() {
     fi
 }
 
+# JSON pools array from "pool=up:dn,..."
+json_pools() {
+    [ "$1" = "-" ] && { echo "[]"; return; }
+    _jp_out=""
+    for _jp_e in $(printf '%s' "$1" | tr ',' ' '); do
+        _jp_p="${_jp_e%%=*}"
+        _jp_v="${_jp_e#*=}"
+        _jp_out="$_jp_out,{\"name\":\"$(json_escape "$_jp_p")\",\"target\":\"$(json_escape "$(pool_target "$_jp_p")")\",\"up\":${_jp_v%%:*},\"down\":${_jp_v##*:}}"
+    done
+    echo "[${_jp_out#,}]"
+}
+
 NOW="$(date +%s)"
 ACCT_T="$(acct_table)"
+HIST="$(acct_history_file)"
 
-hr
-echo "ocserv-server SESSION REPORT : $(date -Is 2>/dev/null || date)"
-if [ -f "$vpngw_state_dir/started" ]; then
-    _since="$(cat "$vpngw_state_dir/started")"
-    echo "Collecting since             : $(ts_fmt "$_since") (container start, $(dur_fmt $((NOW - _since))) ago)"
-fi
-hr
-echo
+ACCT_ACTIVE=1
+[ -f "$vpngw_state_dir/users" ] || ACCT_ACTIVE=0
 
-if [ ! -f "$vpngw_state_dir/users" ]; then
-    echo "Session accounting is inactive: it is collected by the per-user gateway"
-    echo "hook, so it needs gateway mode with a user map (VPN_USER_GATEWAY[_FILE])."
-    echo "For live-only info without it: occtl show users / network-diagnostic."
-    exit 0
-fi
+# ---- Gather active sessions & sample throughput -------------------------------
 
-# ---- Active sessions ---------------------------------------------------------
-
-SUMMARY="/tmp/session-report.$$"
-: > "$SUMMARY"
-trap 'rm -f "$SUMMARY"' EXIT INT TERM
-
-n_active=0
-if [ -d "$vpngw_state_dir/sessions" ]; then
-    for _rec in "$vpngw_state_dir"/sessions/*; do
-        [ -f "$_rec" ] || continue
-        n_active=$((n_active + 1))
-    done
-fi
-echo "### Active sessions ($n_active)"
-if [ "$n_active" = 0 ]; then
-    echo "(none)"
-else
+# One line per active session, matching the history layout so the render loop
+# is shared: conn NOW user ip4 ip6 client gw dev up dn - - pools
+ACTIVE="$TMP_BASE.act"
+: > "$ACTIVE"
+if [ "$ACCT_ACTIVE" = 1 ] && [ -d "$vpngw_state_dir/sessions" ]; then
     for _rec in "$vpngw_state_dir"/sessions/*; do
         [ -f "$_rec" ] || continue
         read -r s_user s_gw s_ip4 s_ip6 s_bp < "$_rec" || continue
@@ -156,41 +204,171 @@ else
                 s_pools="${s_pools:+$s_pools,}$s_p=${s_pu:-0}:${s_pd:-0}"
             done
         fi
+        printf '%s %s %s %s %s %s %s %s %s %s - - %s\n' \
+            "$s_conn" "$NOW" "$s_user" "$s_ip4" "$s_ip6" "$s_client" "$s_gw" \
+            "$s_dev" "${s_up:--}" "${s_dn:--}" "$s_pools" >> "$ACTIVE"
+        [ -n "$s_up" ] && echo "$s_ip4 $s_up ${s_dn:-0}" >> "$RATE_SNAP"
+    done
+fi
+
+# Throughput: re-read the totals after a second; rate = delta.
+RATE_DT=0
+if [ "$DO_RATE" = 1 ] && [ -s "$RATE_SNAP" ]; then
+    sleep 1
+    RATE_DT=$(( $(date +%s) - NOW ))
+    [ "$RATE_DT" -lt 1 ] && RATE_DT=1
+fi
+
+session_rate() { # $1 = ip4 -> "up_bps dn_bps" (empty when not sampled)
+    [ "$RATE_DT" -gt 0 ] || return 0
+    _sr_snap="$(awk -v ip="$1" '$1 == ip { print $2, $3; exit }' "$RATE_SNAP" 2>/dev/null)"
+    [ -n "$_sr_snap" ] || return 0
+    _sr_sid="$(acct_sid "$1")"
+    _sr_up="$(acct_counter_bytes "$ACCT_T" "a_${_sr_sid}_up")"
+    _sr_dn="$(acct_counter_bytes "$ACCT_T" "a_${_sr_sid}_dn")"
+    [ -n "$_sr_up" ] || return 0
+    echo "$(( (_sr_up - ${_sr_snap%% *}) / RATE_DT )) $(( (_sr_dn - ${_sr_snap##* }) / RATE_DT ))"
+}
+
+# Flap check over the completed sessions.
+flap_lines() { # prints "user count" per flapping user
+    [ -s "$HIST" ] || return 0
+    awk -v now="$NOW" -v win="$FLAP_WINDOW" -v short="$FLAP_SHORT" -v min="$FLAP_MIN" '
+        $1 !~ /^[0-9]+$/ || $2 !~ /^[0-9]+$/ { next }
+        $2 >= now - win && ($2 - $1) < short { n[$3]++ }
+        END { for (u in n) if (n[u] >= min) print u, n[u] }' "$HIST"
+}
+
+# ---- JSON mode -----------------------------------------------------------------
+
+if [ "$MODE" = "json" ]; then
+    _j_since="null"
+    [ -f "$vpngw_state_dir/started" ] && _j_since="$(cat "$vpngw_state_dir/started")"
+
+    _j_act=""
+    while read -r a_conn _ a_user a_ip4 a_ip6 a_client a_gw a_dev a_up a_dn _ _ a_pools; do
+        [ -n "$a_user" ] || continue
+        _j_rate_u=null; _j_rate_d=null
+        _j_r="$(session_rate "$a_ip4")"
+        [ -n "$_j_r" ] && { _j_rate_u="${_j_r%% *}"; _j_rate_d="${_j_r##* }"; }
+        _j_act="$_j_act,{\"user\":\"$(json_escape "$a_user")\",\"connected\":$(json_num "$a_conn"),\"assigned_ipv4\":\"$a_ip4\",\"assigned_ipv6\":$(json_str "$a_ip6"),\"client_ip\":$(json_str "$a_client"),\"client_geo\":$(json_str "$(geo_of "$a_client")"),\"device\":$(json_str "$a_dev"),\"gateway\":$(json_str "$a_gw"),\"up\":$(json_num "$a_up"),\"down\":$(json_num "$a_dn"),\"rate_up_bps\":$_j_rate_u,\"rate_down_bps\":$_j_rate_d,\"pools\":$(json_pools "$a_pools")}"
+        _j_su="$a_up"; [ "$_j_su" = "-" ] && _j_su=0
+        _j_sd="$a_dn"; [ "$_j_sd" = "-" ] && _j_sd=0
+        echo "$a_user $_j_su $_j_sd" >> "$SUMMARY"
+    done < "$ACTIVE"
+
+    _j_hist=""
+    if [ -s "$HIST" ]; then
+        while read -r h_conn h_disc h_user h_ip4 h_ip6 h_client h_gw h_dev \
+            h_up h_dn h_ocin h_ocout h_pools; do
+            [ -n "$h_user" ] || continue
+            [ -n "$USER_FILTER" ] && [ "$h_user" != "$USER_FILTER" ] && continue
+            _j_dur=null
+            case "$h_conn$h_disc" in *[!0-9]*) ;; *) _j_dur=$((h_disc - h_conn)) ;; esac
+            _j_hist=",{\"user\":\"$(json_escape "$h_user")\",\"connected\":$(json_num "$h_conn"),\"disconnected\":$(json_num "$h_disc"),\"duration\":$_j_dur,\"assigned_ipv4\":\"$h_ip4\",\"assigned_ipv6\":$(json_str "$h_ip6"),\"client_ip\":$(json_str "$h_client"),\"client_geo\":$(json_str "$(geo_of "$h_client")"),\"device\":$(json_str "$h_dev"),\"gateway\":$(json_str "$h_gw"),\"up\":$(json_num "$h_up"),\"down\":$(json_num "$h_dn"),\"ocserv_up\":$(json_num "$h_ocin"),\"ocserv_down\":$(json_num "$h_ocout"),\"pools\":$(json_pools "$h_pools")}$_j_hist"
+            _j_su="$h_ocin"; [ "$_j_su" = "-" ] && _j_su="$h_up"
+            _j_sd="$h_ocout"; [ "$_j_sd" = "-" ] && _j_sd="$h_dn"
+            case "$_j_su" in -|'') _j_su=0 ;; esac
+            case "$_j_sd" in -|'') _j_sd=0 ;; esac
+            echo "$h_user $_j_su $_j_sd" >> "$SUMMARY"
+        done < "$HIST"
+    fi
+
+    _j_tot=""
+    if [ -s "$SUMMARY" ]; then
+        while read -r t_u t_n t_up t_dn; do
+            _j_tot="$_j_tot,{\"user\":\"$(json_escape "$t_u")\",\"sessions\":$t_n,\"up\":$t_up,\"down\":$t_dn}"
+        done <<EOF
+$(awk '{ n[$1]++; up[$1] += $2; dn[$1] += $3 }
+    END { for (u in n) print u, n[u], up[u], dn[u] }' "$SUMMARY" | sort)
+EOF
+    fi
+
+    _j_flap=""
+    while read -r f_u f_n; do
+        [ -n "$f_u" ] || continue
+        [ -n "$USER_FILTER" ] && [ "$f_u" != "$USER_FILTER" ] && continue
+        _j_flap="$_j_flap,{\"user\":\"$(json_escape "$f_u")\",\"short_sessions_last_hour\":$f_n}"
+    done <<EOF
+$(flap_lines)
+EOF
+
+    printf '{"accounting":%s,"collecting_since":%s,"history_file":"%s","active":[%s],"completed":[%s],"totals":[%s],"flapping":[%s]}\n' \
+        "$([ "$ACCT_ACTIVE" = 1 ] && echo true || echo false)" \
+        "$_j_since" "$(json_escape "$HIST")" \
+        "${_j_act#,}" "${_j_hist#,}" "${_j_tot#,}" "${_j_flap#,}"
+    exit 0
+fi
+
+# ---- Text mode -----------------------------------------------------------------
+
+hr
+echo "ocserv-server SESSION REPORT : $(date -Is 2>/dev/null || date)"
+if [ -f "$vpngw_state_dir/started" ]; then
+    _since="$(cat "$vpngw_state_dir/started")"
+    echo "Collecting since             : $(ts_fmt "$_since") (container start, $(dur_fmt $((NOW - _since))) ago)"
+fi
+[ -n "$session_history_file" ] \
+    && echo "History file                 : $HIST (persistent)"
+hr
+echo
+
+if [ "$ACCT_ACTIVE" = 0 ]; then
+    echo "Session accounting is inactive: it is collected by the per-user gateway"
+    echo "hook, so it needs gateway mode with a user map (VPN_USER_GATEWAY[_FILE])."
+    echo "For live-only info without it: occtl show users / network-diagnostic."
+    exit 0
+fi
+
+n_active="$(grep -c . "$ACTIVE" 2>/dev/null)" || n_active=0
+echo "### Active sessions ($n_active)"
+if [ "$n_active" = 0 ]; then
+    echo "(none)"
+else
+    while read -r a_conn _ a_user a_ip4 a_ip6 a_client a_gw a_dev a_up a_dn _ _ a_pools; do
+        [ -n "$a_user" ] || continue
         _dur="-"
-        case "$s_conn" in *[!0-9]*|'') ;; *) _dur="$(dur_fmt $((NOW - s_conn)))" ;; esac
+        case "$a_conn" in *[!0-9]*|'') ;; *) _dur="$(dur_fmt $((NOW - a_conn)))" ;; esac
+        _geo="$(geo_of "$a_client")"
         echo
-        printf '%s  (%s)\n' "$s_user" "online, connected $(ts_fmt "$s_conn"), up $_dur"
-        printf '    assigned %s%s  client %s  dev %s  gateway %s\n' \
-            "$s_ip4" "$([ "$s_ip6" != "-" ] && echo ", $s_ip6")" "$s_client" "$s_dev" "${s_gw}"
-        if [ -n "$s_up" ]; then
-            printf '    %-24s up %-10s down %s\n' "total (forwarded)" "$(hb "$s_up")" "$(hb "$s_dn")"
-            breakdown "$s_gw" "$s_up" "${s_dn:-0}" "$s_pools"
-            echo "$s_user ${s_up:-0} ${s_dn:-0}" >> "$SUMMARY"
+        printf '%s  (online, connected %s, up %s)\n' "$a_user" "$(ts_fmt "$a_conn")" "$_dur"
+        printf '    assigned %s%s  client %s%s  dev %s  gateway %s\n' \
+            "$a_ip4" "$([ "$a_ip6" != "-" ] && echo ", $a_ip6")" \
+            "$a_client" "${_geo:+ ($_geo)}" "$a_dev" "$a_gw"
+        if [ "$a_up" != "-" ]; then
+            _rate="$(session_rate "$a_ip4")"
+            _rate_s=""
+            [ -n "$_rate" ] \
+                && _rate_s="   [now: up $(hb "${_rate%% *}")/s down $(hb "${_rate##* }")/s]"
+            printf '    %-24s up %-10s down %s%s\n' "total (forwarded)" \
+                "$(hb "$a_up")" "$(hb "$a_dn")" "$_rate_s"
+            breakdown "$a_gw" "$a_up" "$a_dn" "$a_pools"
+            echo "$a_user $a_up $a_dn" >> "$SUMMARY"
         else
             echo "    (no counters - session predates the accounting upgrade?)"
-            echo "$s_user 0 0" >> "$SUMMARY"
+            echo "$a_user 0 0" >> "$SUMMARY"
         fi
-    done
+    done < "$ACTIVE"
 fi
 echo
 
-# ---- Completed sessions --------------------------------------------------------
-
 echo "### Completed sessions (newest first)"
-if [ ! -s "$vpngw_state_dir/history" ]; then
-    echo "(none since container start)"
+if [ ! -s "$HIST" ]; then
+    echo "(none recorded)"
 else
-    tac "$vpngw_state_dir/history" | while read -r h_conn h_disc h_user h_ip4 h_ip6 \
-        h_client h_gw h_dev h_up h_dn h_ocin h_ocout h_pools; do
+    tac "$HIST" | while read -r h_conn h_disc h_user h_ip4 h_ip6 h_client h_gw h_dev \
+        h_up h_dn h_ocin h_ocout h_pools; do
         [ -n "$h_user" ] || continue
         [ -n "$USER_FILTER" ] && [ "$h_user" != "$USER_FILTER" ] && continue
         _dur="-"
         case "$h_conn$h_disc" in *[!0-9]*) ;; *) _dur="$(dur_fmt $((h_disc - h_conn)))" ;; esac
+        _geo="$(geo_of "$h_client")"
         echo
         printf '%s  (connected %s, disconnected %s, duration %s)\n' \
             "$h_user" "$(ts_fmt "$h_conn")" "$(ts_fmt "$h_disc")" "$_dur"
-        printf '    assigned %s%s  client %s  dev %s  gateway %s\n' \
-            "$h_ip4" "$([ "$h_ip6" != "-" ] && echo ", $h_ip6")" "$h_client" "$h_dev" "$h_gw"
+        printf '    assigned %s%s  client %s%s  dev %s  gateway %s\n' \
+            "$h_ip4" "$([ "$h_ip6" != "-" ] && echo ", $h_ip6")" \
+            "$h_client" "${_geo:+ ($_geo)}" "$h_dev" "$h_gw"
         if [ "$h_ocin" != "-" ]; then
             printf '    %-24s up %-10s down %s\n' "total (ocserv)" "$(hb "$h_ocin")" "$(hb "$h_ocout")"
         fi
@@ -198,7 +376,6 @@ else
             printf '    %-24s up %-10s down %s\n' "total (forwarded)" "$(hb "$h_up")" "$(hb "$h_dn")"
         fi
         breakdown "$h_gw" "$h_up" "$h_dn" "$h_pools"
-        # Prefer ocserv's totals for the aggregate; fall back to the counters
         _su="$h_ocin"; _sd="$h_ocout"
         [ "$_su" = "-" ] && { _su="$h_up"; _sd="$h_dn"; }
         case "$_su" in -|'') _su=0; _sd=0 ;; esac
@@ -207,20 +384,26 @@ else
 fi
 echo
 
-# ---- Per-user totals ----------------------------------------------------------
-
 echo "### Per-user totals (active + completed)"
 if [ ! -s "$SUMMARY" ]; then
     echo "(nothing recorded yet)"
 else
-    {
-        printf '%-20s %-9s %-11s %s\n' "user" "sessions" "up" "down"
-        awk '{ n[$1]++; up[$1] += $2; dn[$1] += $3 }
-            END { for (u in n) print u, n[u], up[u], dn[u] }' "$SUMMARY" \
-        | sort | while read -r t_u t_n t_up t_dn; do
-            printf '%-20s %-9s %-11s %s\n' "$t_u" "$t_n" "$(hb "$t_up")" "$(hb "$t_dn")"
-        done
-    }
+    printf '%-20s %-9s %-11s %s\n' "user" "sessions" "up" "down"
+    awk '{ n[$1]++; up[$1] += $2; dn[$1] += $3 }
+        END { for (u in n) print u, n[u], up[u], dn[u] }' "$SUMMARY" \
+    | sort | while read -r t_u t_n t_up t_dn; do
+        printf '%-20s %-9s %-11s %s\n' "$t_u" "$t_n" "$(hb "$t_up")" "$(hb "$t_dn")"
+    done
+fi
+
+_flaps="$(flap_lines)"
+if [ -n "$_flaps" ]; then
+    echo
+    echo "### Reconnect loops"
+    printf '%s\n' "$_flaps" | while read -r f_u f_n; do
+        [ -n "$USER_FILTER" ] && [ "$f_u" != "$USER_FILTER" ] && continue
+        echo "[flap] $f_u: $f_n sessions shorter than $((FLAP_SHORT / 60))m in the last hour - client may be reconnect-looping"
+    done
 fi
 echo
 hr

--- a/rootfs/usr/local/bin/session-report
+++ b/rootfs/usr/local/bin/session-report
@@ -1,0 +1,226 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# session-report - who connected, when, and how much data went where.
+#
+# Active sessions first, then completed ones (newest first). Each session
+# shows its traffic split: how much went through the user's gateway and how
+# much through each attached bypass pool. Data is collected by the ocserv
+# connect/disconnect hook (per-session nft counters + a history record on
+# disconnect), so the report needs gateway mode with a per-user map - exactly
+# the deployments where "which path did the bytes take" is a question.
+#
+# The horizon is CONTAINER start: state lives on tmpfs /run, sessions cannot
+# outlive the container anyway, and an ocserv-only restart inside a running
+# container keeps the history.
+#
+# "up" is client -> world, "down" is world -> client, counted on the forward
+# path. ocserv's own session totals (shown for completed sessions) also
+# include traffic terminating in the container, e.g. tunneled DNS - a small
+# constant gap between the two is normal.
+#
+# Usage: session-report [-u|--user NAME] [-h|--help]
+
+set -u
+
+USER_FILTER=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -u|--user) USER_FILTER="${2:-}"; shift ;;
+        -h|--help)
+            sed -n '3,22s/^# \{0,1\}//p' "$0"
+            exit 0
+            ;;
+        *) echo "Unknown option: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+. /usr/local/bin/backend-functions
+
+hr() { echo "================================================================"; }
+
+hb() { # human-readable byte count ("-" passes through)
+    case "$1" in ''|-) echo "-"; return ;; esac
+    awk -v b="$1" 'BEGIN {
+        u = "B"
+        if (b >= 1024) { b /= 1024; u = "K" }
+        if (b >= 1024) { b /= 1024; u = "M" }
+        if (b >= 1024) { b /= 1024; u = "G" }
+        if (u == "B") printf "%d%s", b, u; else printf "%.1f%s", b, u }'
+}
+
+ts_fmt() { # epoch -> local time ("-" passes through)
+    case "$1" in ''|-|*[!0-9]*) echo "-"; return ;; esac
+    awk -v t="$1" 'BEGIN { print strftime("%Y-%m-%d %H:%M:%S", t) }'
+}
+
+dur_fmt() { # seconds -> 45s / 12m30s / 3h07m / 2d05h
+    case "$1" in ''|-|*[!0-9]*) echo "-"; return ;; esac
+    awk -v s="$1" 'BEGIN {
+        d = int(s / 86400); h = int(s % 86400 / 3600); m = int(s % 3600 / 60)
+        if (d) printf "%dd%02dh", d, h
+        else if (h) printf "%dh%02dm", h, m
+        else if (m) printf "%dm%02ds", m, s % 60
+        else printf "%ds", s }'
+}
+
+pool_target() { # $1 = pool -> its target (direct if unknown)
+    awk -v p="$1" '$1 == p { print $2; exit }' \
+        "$vpngw_state_dir/bypass_targets" 2>/dev/null | grep . || echo direct
+}
+
+# Print the per-path breakdown lines for one session.
+#   $1 = gateway ("-" = default/unmapped, "direct")
+#   $2 = total up bytes (or "-")   $3 = total down bytes (or "-")
+#   $4 = "pool=up:dn,..." (or "-")
+breakdown() {
+    _bk_gw="$1"; _bk_up="$2"; _bk_dn="$3"; _bk_pools="$4"
+    [ "$_bk_up" = "-" ] && [ "$_bk_pools" = "-" ] && return 0
+    _bk_pu_sum=0; _bk_pd_sum=0
+    if [ "$_bk_pools" != "-" ]; then
+        for _bk_e in $(printf '%s' "$_bk_pools" | tr ',' ' '); do
+            _bk_p="${_bk_e%%=*}"
+            _bk_v="${_bk_e#*=}"
+            _bk_pu="${_bk_v%%:*}"; _bk_pd="${_bk_v##*:}"
+            _bk_pu_sum=$((_bk_pu_sum + _bk_pu)); _bk_pd_sum=$((_bk_pd_sum + _bk_pd))
+            printf '    %-24s up %-10s down %s\n' \
+                "pool $_bk_p -> $(pool_target "$_bk_p")" "$(hb "$_bk_pu")" "$(hb "$_bk_pd")"
+        done
+    fi
+    if [ "$_bk_up" != "-" ]; then
+        _bk_gu=$(( _bk_up - _bk_pu_sum )); [ "$_bk_gu" -lt 0 ] && _bk_gu=0
+        _bk_gd=$(( _bk_dn - _bk_pd_sum )); [ "$_bk_gd" -lt 0 ] && _bk_gd=0
+        case "$_bk_gw" in
+            -|direct) _bk_lbl="direct (no gateway)" ;;
+            *)        _bk_lbl="via gateway $_bk_gw" ;;
+        esac
+        printf '    %-24s up %-10s down %s\n' "$_bk_lbl" "$(hb "$_bk_gu")" "$(hb "$_bk_gd")"
+    fi
+}
+
+NOW="$(date +%s)"
+ACCT_T="$(acct_table)"
+
+hr
+echo "ocserv-server SESSION REPORT : $(date -Is 2>/dev/null || date)"
+if [ -f "$vpngw_state_dir/started" ]; then
+    _since="$(cat "$vpngw_state_dir/started")"
+    echo "Collecting since             : $(ts_fmt "$_since") (container start, $(dur_fmt $((NOW - _since))) ago)"
+fi
+hr
+echo
+
+if [ ! -f "$vpngw_state_dir/users" ]; then
+    echo "Session accounting is inactive: it is collected by the per-user gateway"
+    echo "hook, so it needs gateway mode with a user map (VPN_USER_GATEWAY[_FILE])."
+    echo "For live-only info without it: occtl show users / network-diagnostic."
+    exit 0
+fi
+
+# ---- Active sessions ---------------------------------------------------------
+
+SUMMARY="/tmp/session-report.$$"
+: > "$SUMMARY"
+trap 'rm -f "$SUMMARY"' EXIT INT TERM
+
+n_active=0
+if [ -d "$vpngw_state_dir/sessions" ]; then
+    for _rec in "$vpngw_state_dir"/sessions/*; do
+        [ -f "$_rec" ] || continue
+        n_active=$((n_active + 1))
+    done
+fi
+echo "### Active sessions ($n_active)"
+if [ "$n_active" = 0 ]; then
+    echo "(none)"
+else
+    for _rec in "$vpngw_state_dir"/sessions/*; do
+        [ -f "$_rec" ] || continue
+        read -r s_user s_gw s_ip4 s_ip6 s_bp < "$_rec" || continue
+        [ -n "$USER_FILTER" ] && [ "$s_user" != "$USER_FILTER" ] && continue
+        s_conn="-"; s_client="-"; s_dev="-"
+        [ -f "$vpngw_state_dir/acct/$s_ip4" ] \
+            && read -r s_conn s_client s_dev < "$vpngw_state_dir/acct/$s_ip4"
+        s_sid="$(acct_sid "$s_ip4")"
+        s_up="$(acct_counter_bytes "$ACCT_T" "a_${s_sid}_up")"
+        s_dn="$(acct_counter_bytes "$ACCT_T" "a_${s_sid}_dn")"
+        s_pools="-"
+        if [ "$s_bp" != "-" ]; then
+            for s_p in $(printf '%s' "$s_bp" | tr '+' ' '); do
+                s_pi="$(acct_pool_id "$s_p")"
+                s_pu="$(acct_counter_bytes "$ACCT_T" "a_${s_sid}_${s_pi}_up")"
+                s_pd="$(acct_counter_bytes "$ACCT_T" "a_${s_sid}_${s_pi}_dn")"
+                [ -n "$s_pu$s_pd" ] || continue
+                [ "$s_pools" = "-" ] && s_pools=""
+                s_pools="${s_pools:+$s_pools,}$s_p=${s_pu:-0}:${s_pd:-0}"
+            done
+        fi
+        _dur="-"
+        case "$s_conn" in *[!0-9]*|'') ;; *) _dur="$(dur_fmt $((NOW - s_conn)))" ;; esac
+        echo
+        printf '%s  (%s)\n' "$s_user" "online, connected $(ts_fmt "$s_conn"), up $_dur"
+        printf '    assigned %s%s  client %s  dev %s  gateway %s\n' \
+            "$s_ip4" "$([ "$s_ip6" != "-" ] && echo ", $s_ip6")" "$s_client" "$s_dev" "${s_gw}"
+        if [ -n "$s_up" ]; then
+            printf '    %-24s up %-10s down %s\n' "total (forwarded)" "$(hb "$s_up")" "$(hb "$s_dn")"
+            breakdown "$s_gw" "$s_up" "${s_dn:-0}" "$s_pools"
+            echo "$s_user ${s_up:-0} ${s_dn:-0}" >> "$SUMMARY"
+        else
+            echo "    (no counters - session predates the accounting upgrade?)"
+            echo "$s_user 0 0" >> "$SUMMARY"
+        fi
+    done
+fi
+echo
+
+# ---- Completed sessions --------------------------------------------------------
+
+echo "### Completed sessions (newest first)"
+if [ ! -s "$vpngw_state_dir/history" ]; then
+    echo "(none since container start)"
+else
+    tac "$vpngw_state_dir/history" | while read -r h_conn h_disc h_user h_ip4 h_ip6 \
+        h_client h_gw h_dev h_up h_dn h_ocin h_ocout h_pools; do
+        [ -n "$h_user" ] || continue
+        [ -n "$USER_FILTER" ] && [ "$h_user" != "$USER_FILTER" ] && continue
+        _dur="-"
+        case "$h_conn$h_disc" in *[!0-9]*) ;; *) _dur="$(dur_fmt $((h_disc - h_conn)))" ;; esac
+        echo
+        printf '%s  (connected %s, disconnected %s, duration %s)\n' \
+            "$h_user" "$(ts_fmt "$h_conn")" "$(ts_fmt "$h_disc")" "$_dur"
+        printf '    assigned %s%s  client %s  dev %s  gateway %s\n' \
+            "$h_ip4" "$([ "$h_ip6" != "-" ] && echo ", $h_ip6")" "$h_client" "$h_dev" "$h_gw"
+        if [ "$h_ocin" != "-" ]; then
+            printf '    %-24s up %-10s down %s\n' "total (ocserv)" "$(hb "$h_ocin")" "$(hb "$h_ocout")"
+        fi
+        if [ "$h_up" != "-" ]; then
+            printf '    %-24s up %-10s down %s\n' "total (forwarded)" "$(hb "$h_up")" "$(hb "$h_dn")"
+        fi
+        breakdown "$h_gw" "$h_up" "$h_dn" "$h_pools"
+        # Prefer ocserv's totals for the aggregate; fall back to the counters
+        _su="$h_ocin"; _sd="$h_ocout"
+        [ "$_su" = "-" ] && { _su="$h_up"; _sd="$h_dn"; }
+        case "$_su" in -|'') _su=0; _sd=0 ;; esac
+        echo "$h_user $_su ${_sd:-0}" >> "$SUMMARY"
+    done
+fi
+echo
+
+# ---- Per-user totals ----------------------------------------------------------
+
+echo "### Per-user totals (active + completed)"
+if [ ! -s "$SUMMARY" ]; then
+    echo "(nothing recorded yet)"
+else
+    {
+        printf '%-20s %-9s %-11s %s\n' "user" "sessions" "up" "down"
+        awk '{ n[$1]++; up[$1] += $2; dn[$1] += $3 }
+            END { for (u in n) print u, n[u], up[u], dn[u] }' "$SUMMARY" \
+        | sort | while read -r t_u t_n t_up t_dn; do
+            printf '%-20s %-9s %-11s %s\n' "$t_u" "$t_n" "$(hb "$t_up")" "$(hb "$t_dn")"
+        done
+    }
+fi
+echo
+hr

--- a/wiki/Architecture-and-Internals.md
+++ b/wiki/Architecture-and-Internals.md
@@ -84,7 +84,7 @@ All env-var defaults live in one helper, `/usr/local/bin/backend-functions`, whi
 | `/usr/sbin/ocserv`, `/usr/sbin/ocserv-worker` | The server |
 | `/usr/bin/occtl`, `/usr/bin/ocpasswd` | Control + user tools |
 | `/usr/libexec/ocserv-fw` | Per-user firewall helper (nftables) |
-| `/usr/local/bin/` | Helper scripts: `backend-functions` (shared env/config helpers) and the admin commands `network-diagnostic`, `healthcheck` (the Docker health probe), `vpngw-reload`, `vpngw-gw-resolve`, `bypass-reload`, `bypass-fetch`, `cert-reload` (all runnable via `docker exec`) |
+| `/usr/local/bin/` | Helper scripts: `backend-functions` (shared env/config helpers) and the admin commands `network-diagnostic`, `session-report` (per-session traffic accounting), `healthcheck` (the Docker health probe), `vpngw-reload`, `vpngw-gw-resolve`, `bypass-reload`, `bypass-fetch`, `cert-reload` (all runnable via `docker exec`) |
 | `/etc/ocserv/pools/` | Destination-bypass pool lists (`<name>.list`, on your volume) |
 | `/run/ocserv/` | PID + control sockets |
 | `/run/ocserv-vpngw/` | Gateway/bypass runtime state (parsed gateways, user maps, per-session records) |

--- a/wiki/Configuration-Reference.md
+++ b/wiki/Configuration-Reference.md
@@ -79,6 +79,14 @@ Route traffic **by destination**: CIDR pools whose matched traffic exits direct,
 | `CERT_WATCH` | `0` | When `1`, the `svc-cert-watch` service watches the `server-cert`/`server-key` files declared in `ocserv.conf` and sends ocserv a `SIGHUP` (via `cert-reload`) whenever one changes, so a renewed certificate is reloaded **without a container restart** and without dropping live sessions. Relative cert paths are resolved against the `ocserv.conf` directory. Run `docker exec <container> cert-reload` to force one reload. See [Reverse Proxy and Certificates#certificate-renewal](Reverse-Proxy-and-Certificates#certificate-renewal). |
 | `CERT_WATCH_INTERVAL` | `0` | Polling fallback for `CERT_WATCH`, in seconds (`0` = off). When positive, `svc-cert-poll` re-stats the same cert files every N seconds and reloads ocserv when their mtime/size changes — for filesystems where `inotify` doesn't deliver events (e.g. an **NFS-backed** cert directory). `stat` follows symlinks, so a certbot `live`→`archive` re-link is detected. Prefer `CERT_WATCH=1` on local/bind-mounted directories; use this where inotify can't work. Both may be set (reloads are idempotent), but normally you pick one. |
 
+### Session accounting
+
+Per-session traffic accounting for `session-report`. Feature guide: [[Session Accounting]].
+
+| Variable | Default | Description |
+|---|---|---|
+| `SESSION_HISTORY_FILE` | _(unset — tmpfs)_ | Where completed sessions are appended (one line each). By default the history lives on tmpfs and covers the container lifetime; point this at the config volume (e.g. `/etc/ocserv/session-history`) to keep it across container recreations. Rotate/truncate it yourself when needed. |
+
 ### Health monitor
 
 Opt-in Docker `HEALTHCHECK` probe. Feature guide: [[Health Monitor]].

--- a/wiki/Destination-Bypass.md
+++ b/wiki/Destination-Bypass.md
@@ -182,6 +182,7 @@ docker exec <container> nft list table inet ocserv_bypass    # pools + subscribe
 docker exec <container> ip rule                              # the fwmark rules at prio 800
 docker exec <container> cat /run/ocserv-vpngw/bypass_targets # pool -> target -> mark
 docker exec <container> cat /run/ocserv-vpngw/bypass_users   # effective per-user map
+docker exec <container> session-report                       # per-session bytes through each pool vs the gateway
 ```
 
 ---

--- a/wiki/Gateway-Mode.md
+++ b/wiki/Gateway-Mode.md
@@ -277,6 +277,8 @@ The quickest check is the built-in diagnostic — it probes egress **through eve
 docker exec ocserv-server network-diagnostic
 ```
 
+For per-session traffic — who connected when, and how many bytes took the gateway versus a bypass pool — see **[[Session Accounting]]** (`docker exec ocserv-server session-report`).
+
 Or inspect the pieces by hand:
 
 ```bash

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -18,6 +18,7 @@ It runs unmodified ocserv, so every client and protocol ocserv supports works he
 - **Per-user routing** — map each user to a different upstream gateway; hot-reloadable, no static IPs needed
 - **Destination bypass** — route by destination: country pools direct, chosen services via a specific exit, ad/malware pools blocked; lists auto-fetched and hot-reloaded
 - **Certificate hot-reload** — a renewed Let's Encrypt cert is picked up without a restart or dropped sessions
+- **Session accounting** — `session-report` shows every session's connect/disconnect times and its traffic split per gateway and bypass pool
 - **Opt-in health monitor** — Docker-native `HEALTHCHECK`: server liveness, routing integrity, and (optionally) real egress probes per gateway
 - **Reverse-proxy friendly** — designed to share Let's Encrypt certificates with [SWAG](https://github.com/linuxserver/docker-swag)
 - **Multi-arch images** published to GHCR (and Docker Hub for releases)
@@ -37,6 +38,7 @@ It runs unmodified ocserv, so every client and protocol ocserv supports works he
 | Understand NAT, routing, full vs split tunnel | **[[Networking NAT and Routing]]** |
 | Route clients out through another VPN (e.g. NordVPN) | **[[Gateway Mode]]** |
 | Route by destination — bypass pools, per-service exits, blocklists | **[[Destination Bypass]]** |
+| See who connected and how much data went through which path | **[[Session Accounting]]** |
 | Report container health to Docker / monitoring | **[[Health Monitor]]** |
 | Connect a client or router | **[[Clients and Devices]]** |
 | See how the image is built internally | **[[Architecture and Internals]]** |

--- a/wiki/Session-Accounting.md
+++ b/wiki/Session-Accounting.md
@@ -5,7 +5,10 @@
 ```bash
 docker exec <container> session-report              # everything
 docker exec <container> session-report -u alice     # one user
+docker exec <container> session-report --json       # machine-readable, same data
 ```
+
+Options: `-u NAME` (one user) · `-j/--json` · `--no-geo` (skip client-IP geolocation, faster offline) · `--no-rate` (skip the 1-second throughput sampling of active sessions).
 
 ```
 ================================================================
@@ -15,27 +18,30 @@ Collecting since             : 2026-08-02 09:23:41 (container start, 15h57m ago)
 
 ### Active sessions (2)
 
-mt3000  (online, connected 2026-08-03 00:59:34, up 20m37s)
-    assigned 10.30.0.126  client 95.26.152.156  dev vpns3  gateway mt
-    total (forwarded)        up 321.7K     down 636.1K
+alice  (online, connected 2026-08-03 00:59:34, up 20m37s)
+    assigned 10.20.0.37  client 198.51.100.7 (Amsterdam, NL - AS64496 ExampleNet)  dev vpns3  gateway nl
+    total (forwarded)        up 321.7K     down 636.1K   [now: up 12.4K/s down 1.1M/s]
     pool ru -> direct        up 21.7K      down 96.1K
-    via gateway mt           up 300.0K     down 540.0K
+    via gateway nl           up 300.0K     down 540.0K
 ...
 
 ### Completed sessions (newest first)
 
-balashova  (connected 2026-08-02 09:24:02, disconnected 2026-08-03 00:58:47, duration 15h34m)
-    assigned 10.30.0.110  client 89.109.51.57  dev vpns1  gateway bal
+bob  (connected 2026-08-02 09:24:02, disconnected 2026-08-03 00:58:47, duration 15h34m)
+    assigned 10.20.0.52  client 203.0.113.80 (Berlin, DE - AS64511 ExampleCom)  dev vpns1  gateway us
     total (ocserv)           up 89.1M      down 1.1G
     total (forwarded)        up 88.9M      down 1.1G
     pool ru -> direct        up 12.1M      down 220.4M
-    via gateway bal          up 76.8M      down 0.9G
+    via gateway us           up 76.8M      down 0.9G
 ...
 
 ### Per-user totals (active + completed)
 user                 sessions  up          down
-balashova            2         98.2M       1.2G
+bob                  2         98.2M       1.2G
 ...
+
+### Reconnect loops
+[flap] alice: 4 sessions shorter than 2m in the last hour - client may be reconnect-looping
 ```
 
 ## How it works
@@ -50,6 +56,9 @@ The [gateway-mode connect/disconnect hook](Gateway-Mode) already runs for every 
 ## Reading the numbers
 
 - **up** is client → world, **down** is world → client.
+- **`[now: up …/s down …/s]`** on active sessions is live throughput, sampled over one second at report time (`--no-rate` skips the sampling and the 1s wait).
+- **Client geolocation** (`(Amsterdam, NL - …)` after the client IP) is looked up over the network at report time and silently omitted when unreachable; `--no-geo` skips the attempt.
+- **Reconnect loops**: a user with 3 or more completed sessions shorter than 2 minutes within the last hour gets flagged — the classic signature of a router stuck in a reconnect loop.
 - **total (forwarded)** counts traffic actually forwarded between the tunnel and the WAN — the numbers the per-path split is computed from (`via gateway` = total − all pools).
 - **total (ocserv)** (completed sessions) is ocserv's own count of tunnel bytes. It also includes traffic that terminates *in* the container — tunneled DNS, for example — so it is normally slightly higher than the forwarded total.
 - A pool's share counts traffic to/from that pool's addresses **as attached at connect time**; if you change a user's pools with `vpngw-reload` mid-session, routing follows immediately but the new pool's counters start with the next session.
@@ -57,13 +66,26 @@ The [gateway-mode connect/disconnect hook](Gateway-Mode) already runs for every 
 
 ## Data lifetime
 
-Everything lives on tmpfs (`/run/ocserv-vpngw/`): **history covers the current container lifetime**. Sessions cannot outlive the container anyway, and an ocserv-only restart inside a running container keeps the collected history. `Collecting since` in the header tells you the horizon. If you need long-term accounting, ship the history file off the container periodically:
+By default everything lives on tmpfs (`/run/ocserv-vpngw/`): **history covers the current container lifetime**. Sessions cannot outlive the container anyway, and an ocserv-only restart inside a running container keeps the collected history. `Collecting since` in the header tells you the horizon.
 
-```bash
-docker exec <container> cat /run/ocserv-vpngw/history >> /var/log/ocserv-sessions.log
+For accounting that survives container recreations, point the history at the config volume:
+
+```yaml
+environment:
+  - SESSION_HISTORY_FILE=/etc/ocserv/session-history
 ```
 
-(One line per completed session: `connect-epoch disconnect-epoch user ip4 ip6 client-ip gateway device up down ocserv-in ocserv-out pool=up:down,...` — stable, machine-parseable.)
+| Variable | Default | Description |
+|---|---|---|
+| `SESSION_HISTORY_FILE` | _(unset — tmpfs)_ | Where completed sessions are appended. Put it on a volume to keep history across container recreations. The file grows one line per session; rotate or truncate it yourself when needed. |
+
+The format is stable and machine-parseable, one line per completed session:
+
+```
+connect-epoch disconnect-epoch user ip4 ip6 client-ip gateway device up down ocserv-in ocserv-out pool=up:down,...
+```
+
+(`-` marks an unknown field; `--json` serves the same data already parsed.)
 
 ---
 

--- a/wiki/Session-Accounting.md
+++ b/wiki/Session-Accounting.md
@@ -1,0 +1,70 @@
+# Session Accounting — who transferred what, where
+
+**`session-report`** answers the questions `occtl` can't: when did each client connect and disconnect, how much data did the session move, and — the part unique to this image — **how much of it went through the user's gateway versus each attached [bypass pool](Destination-Bypass)**.
+
+```bash
+docker exec <container> session-report              # everything
+docker exec <container> session-report -u alice     # one user
+```
+
+```
+================================================================
+ocserv-server SESSION REPORT : 2026-08-03T01:20:11+03:00
+Collecting since             : 2026-08-02 09:23:41 (container start, 15h57m ago)
+================================================================
+
+### Active sessions (2)
+
+mt3000  (online, connected 2026-08-03 00:59:34, up 20m37s)
+    assigned 10.30.0.126  client 95.26.152.156  dev vpns3  gateway mt
+    total (forwarded)        up 321.7K     down 636.1K
+    pool ru -> direct        up 21.7K      down 96.1K
+    via gateway mt           up 300.0K     down 540.0K
+...
+
+### Completed sessions (newest first)
+
+balashova  (connected 2026-08-02 09:24:02, disconnected 2026-08-03 00:58:47, duration 15h34m)
+    assigned 10.30.0.110  client 89.109.51.57  dev vpns1  gateway bal
+    total (ocserv)           up 89.1M      down 1.1G
+    total (forwarded)        up 88.9M      down 1.1G
+    pool ru -> direct        up 12.1M      down 220.4M
+    via gateway bal          up 76.8M      down 0.9G
+...
+
+### Per-user totals (active + completed)
+user                 sessions  up          down
+balashova            2         98.2M       1.2G
+...
+```
+
+## How it works
+
+The [gateway-mode connect/disconnect hook](Gateway-Mode) already runs for every session. It now additionally:
+
+- **on connect** — records the connect time, the client's real IP and the tun device, and installs per-session **nftables counters**: one up/down pair for the session total and one pair per attached bypass pool (matching the pool's address sets, both families);
+- **on disconnect** — snapshots the counters together with ocserv's own session totals into a history file, then removes everything it installed.
+
+`session-report` reads the live counters for active sessions and the history file for completed ones. There is nothing to configure and no measurable overhead — accounting is active whenever gateway mode with a per-user map (`VPN_USER_GATEWAY[_FILE]`) is, i.e. whenever the hook runs. Without gateway mode there is no path split to report; use `occtl show users` / [network-diagnostic](Troubleshooting) for live state.
+
+## Reading the numbers
+
+- **up** is client → world, **down** is world → client.
+- **total (forwarded)** counts traffic actually forwarded between the tunnel and the WAN — the numbers the per-path split is computed from (`via gateway` = total − all pools).
+- **total (ocserv)** (completed sessions) is ocserv's own count of tunnel bytes. It also includes traffic that terminates *in* the container — tunneled DNS, for example — so it is normally slightly higher than the forwarded total.
+- A pool's share counts traffic to/from that pool's addresses **as attached at connect time**; if you change a user's pools with `vpngw-reload` mid-session, routing follows immediately but the new pool's counters start with the next session.
+- Traffic that the [kill switch](Gateway-Mode#the-kill-switch) rejects (fail-closed drops) is counted as "up" — the client did send it — but never produces "down" bytes.
+
+## Data lifetime
+
+Everything lives on tmpfs (`/run/ocserv-vpngw/`): **history covers the current container lifetime**. Sessions cannot outlive the container anyway, and an ocserv-only restart inside a running container keeps the collected history. `Collecting since` in the header tells you the horizon. If you need long-term accounting, ship the history file off the container periodically:
+
+```bash
+docker exec <container> cat /run/ocserv-vpngw/history >> /var/log/ocserv-sessions.log
+```
+
+(One line per completed session: `connect-epoch disconnect-epoch user ip4 ip6 client-ip gateway device up down ocserv-in ocserv-out pool=up:down,...` — stable, machine-parseable.)
+
+---
+
+Next: **[[Gateway Mode]]** · **[[Destination Bypass]]** · **[[Troubleshooting]]**

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -17,6 +17,7 @@
 - [[Networking NAT and Routing]]
 - [[Gateway Mode]]
 - [[Destination Bypass]]
+- [[Session Accounting]]
 - [[Health Monitor]]
 - [[Clients and Devices]]
 


### PR DESCRIPTION
New admin command **`session-report`** — per-session connect/disconnect times and the traffic split between the user's gateway and every attached bypass pool (one line per pool when several are attached).

```
### Active sessions (2)

alice  (online, connected 2026-08-03 00:59:34, up 20m37s)
    assigned 10.20.0.37  client 198.51.100.7 (Amsterdam, NL - AS64496 ExampleNet)  dev vpns3  gateway nl
    total (forwarded)        up 321.7K     down 636.1K   [now: up 12.4K/s down 1.1M/s]
    pool ru -> direct        up 21.7K      down 96.1K
    pool ads -> block        up 1.2K       down 0B
    via gateway nl           up 300.0K     down 540.0K

### Completed sessions (newest first)
...
### Per-user totals (active + completed)
...
### Reconnect loops
[flap] alice: 4 sessions shorter than 2m in the last hour - client may be reconnect-looping
```

Also: `--json` (machine-readable, same data), client-IP geolocation (`--no-geo` to skip), live throughput sampled over 1s for active sessions (`--no-rate` to skip), and `SESSION_HISTORY_FILE` to persist the history on a volume across container recreations (default: tmpfs, container lifetime).

## How it collects

The existing connect/disconnect hook now also:
- **connect**: records connect time / client real IP / tun device, and installs per-session **named nft counters** — an up/down pair for the session total plus one pair per attached pool (matching the pool's interval sets, both families). A dispatch chain (forward hook, prio filter−30) routes packets through per-session chains via **verdict maps keyed by address**, so teardown never has to delete rules by handle.
- **disconnect**: snapshots the counters together with ocserv's own `STATS_BYTES_IN/OUT` into the history file, then removes the session's map entries, chain and counters.

**Overlapping pools count like they route**: totals are counted first, then one block per pool in marking-rule order (bypass_pools order), each ending with `return` on match — first pool wins, so the per-pool numbers always sum to at most the total and the gateway share is exact.

Counters live alongside the pool sets in `inet ocserv_bypass` (nft cannot reference sets across tables; without bypass they go to `inet ocserv_gw`) — both tables are only recreated at container start, and the gw-resolver only flushes the forward chain. **Best-effort by design**: a session that cannot be counted still connects.

## Decisions

- **Horizon = container start** by default (tmpfs `/run`); `SESSION_HISTORY_FILE` opts into persistence. The header prints `Collecting since`.
- Accounting is on whenever the per-user gateway hook runs; overhead is a few counter rules per session.
- ocserv has no log file to mine (it logs to the container's stdout) — the hook's environment contract is the reliable source.

## Testing

Live container (dev image, gateway + pools, hook invoked with ocserv's env contract): counters/chains/map entries created per session (mapped + unmapped users, multiple pools), real packets verified the first-match-wins split, disconnect writes history and leaves zero leftover nft objects, reconnect aggregates per-user totals, `--json` validates, `-u` filter / `--help` / `--no-geo` / `--no-rate` OK.

Docs: new wiki page **Session Accounting**, sidebar/Home/Architecture updates, README key-features row, pointers from Gateway-Mode and Destination-Bypass.