### PR TITLE
session-report: per-user totals broken down by path

### DIFF
--- a/rootfs/usr/local/bin/session-report
+++ b/rootfs/usr/local/bin/session-report
@@ -53,10 +53,12 @@ FLAP_MIN=3
 
 TMP_BASE="/tmp/session-report.$$"
 SUMMARY="$TMP_BASE.sum"
+PATHS="$TMP_BASE.paths"
 GEO_CACHE="$TMP_BASE.geo"
 RATE_SNAP="$TMP_BASE.rate"
 : > "$SUMMARY"
-trap 'rm -f "$SUMMARY" "$GEO_CACHE" "$RATE_SNAP"' EXIT INT TERM
+: > "$PATHS"
+trap 'rm -f "$SUMMARY" "$PATHS" "$GEO_CACHE" "$RATE_SNAP" "$TMP_BASE.act"' EXIT INT TERM
 
 hr() { echo "================================================================"; }
 
@@ -157,6 +159,50 @@ breakdown() {
     fi
 }
 
+# Attribute one session's bytes to per-user path buckets for the totals
+# section: the gateway share to "via:<gw>" (or "direct" for unmapped users),
+# each pool's share to its target ("direct", "blocked", or "via:<gw>").
+# Skipped when the session has no counters.
+#   $1 = user  $2 = gateway  $3 = up  $4 = down  $5 = "pool=up:dn,..."
+emit_paths() {
+    case "$3" in ''|-) return 0 ;; esac
+    _ep_pu=0; _ep_pd=0
+    if [ "$5" != "-" ]; then
+        for _ep_e in $(printf '%s' "$5" | tr ',' ' '); do
+            _ep_p="${_ep_e%%=*}"
+            _ep_v="${_ep_e#*=}"
+            _ep_u="${_ep_v%%:*}"; _ep_d="${_ep_v##*:}"
+            _ep_pu=$((_ep_pu + _ep_u)); _ep_pd=$((_ep_pd + _ep_d))
+            _ep_t="$(pool_target "$_ep_p")"
+            case "$_ep_t" in
+                direct)     _ep_lbl="direct" ;;
+                block|drop) _ep_lbl="blocked" ;;
+                *)          _ep_lbl="via:$_ep_t" ;;
+            esac
+            echo "$1 $_ep_lbl $_ep_u $_ep_d" >> "$PATHS"
+        done
+    fi
+    _ep_gu=$(( $3 - _ep_pu )); [ "$_ep_gu" -lt 0 ] && _ep_gu=0
+    _ep_gd=$(( $4 - _ep_pd )); [ "$_ep_gd" -lt 0 ] && _ep_gd=0
+    case "$2" in
+        -|direct) echo "$1 direct $_ep_gu $_ep_gd" >> "$PATHS" ;;
+        *)        echo "$1 via:$2 $_ep_gu $_ep_gd" >> "$PATHS" ;;
+    esac
+}
+
+path_label() { # "via:nl" -> "via gateway nl", "blocked" -> "blocked (rejected)"
+    case "$1" in
+        via:*)   echo "via gateway ${1#via:}" ;;
+        blocked) echo "blocked (rejected)" ;;
+        *)       echo "$1" ;;
+    esac
+}
+
+user_paths() { # $1 = user -> "bucket up down" lines, aggregated and sorted
+    awk -v u="$1" '$1 == u { up[$2] += $3; dn[$2] += $4 }
+        END { for (k in up) print k, up[k], dn[k] }' "$PATHS" | sort
+}
+
 # JSON pools array from "pool=up:dn,..."
 json_pools() {
     [ "$1" = "-" ] && { echo "[]"; return; }
@@ -208,6 +254,7 @@ if [ "$ACCT_ACTIVE" = 1 ] && [ -d "$vpngw_state_dir/sessions" ]; then
             "$s_conn" "$NOW" "$s_user" "$s_ip4" "$s_ip6" "$s_client" "$s_gw" \
             "$s_dev" "${s_up:--}" "${s_dn:--}" "$s_pools" >> "$ACTIVE"
         [ -n "$s_up" ] && echo "$s_ip4 $s_up ${s_dn:-0}" >> "$RATE_SNAP"
+        emit_paths "$s_user" "$s_gw" "${s_up:--}" "${s_dn:-0}" "$s_pools"
     done
 fi
 
@@ -271,13 +318,21 @@ if [ "$MODE" = "json" ]; then
             case "$_j_su" in -|'') _j_su=0 ;; esac
             case "$_j_sd" in -|'') _j_sd=0 ;; esac
             echo "$h_user $_j_su $_j_sd" >> "$SUMMARY"
+            emit_paths "$h_user" "$h_gw" "$h_up" "$h_dn" "$h_pools"
         done < "$HIST"
     fi
 
     _j_tot=""
     if [ -s "$SUMMARY" ]; then
         while read -r t_u t_n t_up t_dn; do
-            _j_tot="$_j_tot,{\"user\":\"$(json_escape "$t_u")\",\"sessions\":$t_n,\"up\":$t_up,\"down\":$t_dn}"
+            _j_paths=""
+            while read -r p_k p_u p_d; do
+                [ -n "$p_k" ] || continue
+                _j_paths="$_j_paths,{\"path\":\"$(json_escape "$(path_label "$p_k")")\",\"up\":$p_u,\"down\":$p_d}"
+            done <<EOP
+$(user_paths "$t_u")
+EOP
+            _j_tot="$_j_tot,{\"user\":\"$(json_escape "$t_u")\",\"sessions\":$t_n,\"up\":$t_up,\"down\":$t_dn,\"paths\":[${_j_paths#,}]}"
         done <<EOF
 $(awk '{ n[$1]++; up[$1] += $2; dn[$1] += $3 }
     END { for (u in n) print u, n[u], up[u], dn[u] }' "$SUMMARY" | sort)
@@ -380,6 +435,7 @@ else
         [ "$_su" = "-" ] && { _su="$h_up"; _sd="$h_dn"; }
         case "$_su" in -|'') _su=0; _sd=0 ;; esac
         echo "$h_user $_su ${_sd:-0}" >> "$SUMMARY"
+        emit_paths "$h_user" "$h_gw" "$h_up" "$h_dn" "$h_pools"
     done
 fi
 echo
@@ -393,6 +449,10 @@ else
         END { for (u in n) print u, n[u], up[u], dn[u] }' "$SUMMARY" \
     | sort | while read -r t_u t_n t_up t_dn; do
         printf '%-20s %-9s %-11s %s\n' "$t_u" "$t_n" "$(hb "$t_up")" "$(hb "$t_dn")"
+        user_paths "$t_u" | while read -r p_k p_u p_d; do
+            printf '    %-24s up %-10s down %s\n' \
+                "$(path_label "$p_k")" "$(hb "$p_u")" "$(hb "$p_d")"
+        done
     done
 fi
 

--- a/wiki/Session-Accounting.md
+++ b/wiki/Session-Accounting.md
@@ -38,6 +38,9 @@ bob  (connected 2026-08-02 09:24:02, disconnected 2026-08-03 00:58:47, duration 
 ### Per-user totals (active + completed)
 user                 sessions  up          down
 bob                  2         98.2M       1.2G
+    via gateway us           up 76.8M      down 0.9G
+    direct                   up 12.1M      down 220.4M
+    blocked (rejected)       up 45.1K      down 0B
 ...
 
 ### Reconnect loops
@@ -59,6 +62,7 @@ The [gateway-mode connect/disconnect hook](Gateway-Mode) already runs for every 
 - **`[now: up …/s down …/s]`** on active sessions is live throughput, sampled over one second at report time (`--no-rate` skips the sampling and the 1s wait).
 - **Client geolocation** (`(Amsterdam, NL - …)` after the client IP) is looked up over the network at report time and silently omitted when unreachable; `--no-geo` skips the attempt.
 - **Reconnect loops**: a user with 3 or more completed sessions shorter than 2 minutes within the last hour gets flagged — the classic signature of a router stuck in a reconnect loop.
+- **Per-user totals** are broken down by where the bytes went, aggregated across all of the user's sessions: one line per gateway used, one `direct` line (direct-target pools plus unmapped sessions), and one `blocked (rejected)` line (attempts into `block`-target pools — upload only, since rejected traffic never returns).
 - **total (forwarded)** counts traffic actually forwarded between the tunnel and the WAN — the numbers the per-path split is computed from (`via gateway` = total − all pools).
 - **total (ocserv)** (completed sessions) is ocserv's own count of tunnel bytes. It also includes traffic that terminates *in* the container — tunneled DNS, for example — so it is normally slightly higher than the forwarded total.
 - A pool's share counts traffic to/from that pool's addresses **as attached at connect time**; if you change a user's pools with `vpngw-reload` mid-session, routing follows immediately but the new pool's counters start with the next session.


### PR DESCRIPTION
Follow-up to #122: the **Per-user totals** section now shows where each user's bytes went, aggregated across all their sessions:

```
### Per-user totals (active + completed)
user                 sessions  up          down
bob                  2         98.2M       1.2G
    via gateway us           up 76.8M      down 0.9G
    direct                   up 12.1M      down 220.4M
    blocked (rejected)       up 45.1K      down 0B
```

- one line per **gateway** the user's sessions exited through (covers gateway-target pools too),
- **direct** — direct-target pools plus sessions of unmapped users,
- **blocked (rejected)** — attempts into `block`-target pools; upload only, since rejected traffic never produces return bytes.

`--json` grows a `paths` array inside each totals entry.

## Testing
Live container, one user driven through all three path types with real forwarded packets: direct pool **2140B**, blocked pool **384B up / 0B down** (counted before the kill-switch reject, as intended), gateway **156B** — buckets sum exactly to the forwarded total; JSON validated.