### PR TITLE
diag: derive the useful signals from occtl's stats period

### DIFF
--- a/rootfs/usr/local/bin/network-diagnostic
+++ b/rootfs/usr/local/bin/network-diagnostic
@@ -645,6 +645,32 @@ case "$_ocs" in
     *"General info:"*) printf '%s\n' "$_ocs" | awk '/^General info:/ { f = 1 } /^Current stats period:/ { exit } f' ;;
     *) printf '%s\n' "$_ocs" ;;
 esac
+# Derived from the "Current stats period" block (not dumped raw: its RX/TX
+# and session-time figures update only on disconnect and mislead). The error
+# counter is the one real signal - abnormal endings (TLS/transport drops,
+# roaming clients) and fail-closed hook rejections both land there.
+occtl_field() { # $1 = label -> value (last match: period fields come last)
+    printf '%s\n' "$_ocs" | sed -n "s/^[[:space:]]*$1:[[:space:]]*//p" | tail -1
+}
+_sh="$(occtl_field "Sessions handled")"
+if [ -n "$_sh" ]; then
+    _st="$(occtl_field "Timed out sessions")"
+    _si="$(occtl_field "Timed out (idle) sessions")"
+    _se="$(occtl_field "Closed due to error sessions")"
+    _sa="$(occtl_field "Authentication failures")"
+    echo "sessions since stats reset     : $_sh handled, ${_st:-0} timed out, ${_si:-0} idle-dropped, ${_se:-0} closed on error (reset: $(occtl_field "Last stats reset"))"
+    if [ "${_se:-0}" -gt 0 ] 2>/dev/null; then
+        info "$_se session(s) closed on error: abnormal endings - TLS/transport drops and roaming clients count here, and so does a fail-closed gateway rejection; cross-check session-report's reconnect loops"
+    fi
+    if [ "${_sa:-0}" -gt 0 ] 2>/dev/null; then
+        info "$_sa authentication failure(s) since the stats reset - repeated failures ban the source IP (see below / occtl show ip ban points)"
+    fi
+fi
+_bans="$(printf '%s\n' "$_ocs" | sed -n 's/^[[:space:]]*IPs in ban list:[[:space:]]*//p' | head -1)"
+if [ "${_bans:-0}" -gt 0 ] 2>/dev/null; then
+    echo "banned IPs (occtl show ip bans):"
+    occtl_show show ip bans
+fi
 echo
 
 section "Listening sockets"


### PR DESCRIPTION
Follow-up to #121, which dropped the raw `Current stats period` dump. Investigation showed three signals in it worth keeping — in derived form, with context:

```
### occtl status (general info)
General info:
        ...
sessions since stats reset     : 16 handled, 2 timed out, 1 idle-dropped, 4 closed on error (reset: 2026-07-30 12:00 (1d))
[info] 4 session(s) closed on error: abnormal endings - TLS/transport drops and roaming clients count here, and so does a fail-closed gateway rejection; cross-check session-report's reconnect loops
[info] 3 authentication failure(s) since the stats reset - repeated failures ban the source IP (see below / occtl show ip ban points)
banned IPs (occtl show ip bans):
198.51.100.66 (expires in 4m)
```

- **closed on error** is the one real signal the old block had: TLS/transport drops, roaming clients, and our fail-closed hook rejections all land in that counter — as a bare number it read as a problem, with context it's diagnostic (info, never a warn).
- **period auth failures** complement the never-resetting General-info total: nonzero here means the failures are *recent*.
- **banned IPs listed** when the ban count is non-zero — new value the old block never had; instantly explains "user suddenly can't connect".

Still excluded, on purpose: RX/TX and average/max session time (update only on disconnect → near-zero on servers with long-lived sessions, which is exactly what made the raw block misleading), auth-time averages.

Tested with the stub harness (derived line, both infos, ban listing, and the parser picking the period auth count over the all-time total).