### PR TITLE
Image version and build time visible from inside the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,9 @@ RUN echo "**** install security fix packages ****" && \
 ############################
 FROM alpine:${ALPINE_VERSION} AS rootfs
 
+ARG IMAGE_VERSION=N/A \
+    BUILD_DATE=N/A
+
 RUN mkdir -p /rootfs
 
 ADD rootfs/ /rootfs/
@@ -107,6 +110,25 @@ RUN chmod +x /rootfs/usr/local/bin/* || true && \
 
 COPY --from=s6-fetch     /s6root/ /rootfs/
 COPY --from=ocserv-build /pkg/    /rootfs/
+
+# Stamp the image identity into backend-functions (every script sources it).
+# LAST step of the stage on purpose: the ARG values change per build, so only
+# this layer (and the final COPY --from=rootfs) miss the cache.
+RUN safe_sed() { \
+        pattern="$1"; \
+        replacement="$2"; \
+        file="$3"; \
+        for delim in '/' '|' '#' '@' '%' '^' '&' '*' '+' '-' '_' '=' ':' ';' '<' '>' ',' '.' '?' '~'; do \
+            if [ "${replacement%%*"$delim"*}" = "$replacement" ]; then \
+                sed -i "s${delim}${pattern}${delim}${replacement}${delim}g" "$file"; \
+                return; \
+            fi; \
+        done; \
+        echo "No safe delimiter found for $pattern in $file" >&2; \
+        return 1; \
+    } && \
+    safe_sed "__IMAGE_VERSION__" "${IMAGE_VERSION}" /rootfs/usr/local/bin/backend-functions && \
+    safe_sed "__BUILD_DATE__" "${BUILD_DATE}" /rootfs/usr/local/bin/backend-functions
 
 ############################
 # 4) Final runtime (minimal layers)

--- a/rootfs/etc/s6-overlay/s6-rc.d/init-config/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/init-config/run
@@ -5,6 +5,8 @@ set -eu
 
 . /usr/local/bin/backend-functions
 
+log "[INIT-CONFIG] ocserv-server image $image_version, built $image_build_date"
+
 log "[INIT-CONFIG] Ensuring ocserv configuration file exists"
 
 # Create default config if missing

--- a/rootfs/usr/local/bin/backend-functions
+++ b/rootfs/usr/local/bin/backend-functions
@@ -1,6 +1,16 @@
 #!/bin/sh
 # shellcheck shell=sh
 
+# Substituted at image build time (safe_sed in the Dockerfile's rootfs stage):
+# CI passes the image tag ('dev' for main, the version for releases) and a UTC
+# build timestamp; a local docker build without build-args yields N/A. A value
+# still carrying the "__" prefix means an unsubstituted dev copy (script
+# bind-mounted from the repo) - fall back to N/A instead of the placeholder.
+image_version="__IMAGE_VERSION__"
+image_build_date="__BUILD_DATE__"
+case "$image_version" in __*) image_version="N/A" ;; esac
+case "$image_build_date" in __*) image_build_date="N/A" ;; esac
+
 setcap_net_bind="${SETCAP_NET_BIND:-1}"
 setcap_net_admin="${SETCAP_NET_ADMIN:-1}"
 vpn_subnet="${VPN_SUBNET:-10.10.10.0/24}"

--- a/rootfs/usr/local/bin/network-diagnostic
+++ b/rootfs/usr/local/bin/network-diagnostic
@@ -615,7 +615,8 @@ if [ "$MODE" = "json" ]; then
     _run=false;  [ -n "$OCSERV_PID" ] && _run=true
     [ -n "$OCSERV_PID" ] || note_warn "ocserv is not running"
 
-    printf '{"server":{"running":%s,"pid":%s,"version":"%s","clients":%s},"config":{"vpn_subnet":"%s","subnet_match":%s,"camouflage":%s},"direct":{"egress4":%s,"egress6":%s},"gateways":[%s],"clients":[%s],"bypass_pools":[%s],"certificates":[%s],"tables":{"nat":%s,"killswitch":%s,"bypass":%s},"warnings":%s}\n' \
+    printf '{"image":{"version":"%s","built":"%s"},"server":{"running":%s,"pid":%s,"version":"%s","clients":%s},"config":{"vpn_subnet":"%s","subnet_match":%s,"camouflage":%s},"direct":{"egress4":%s,"egress6":%s},"gateways":[%s],"clients":[%s],"bypass_pools":[%s],"certificates":[%s],"tables":{"nat":%s,"killswitch":%s,"bypass":%s},"warnings":%s}\n' \
+        "$(json_escape "$image_version")" "$(json_escape "$image_build_date")" \
         "$_run" "${OCSERV_PID:-null}" "$(json_escape "$(ocserv --version 2>&1 | head -1)")" "$CONNECTED" \
         "$vpn_subnet" "$_match" "$([ "$(conf_get camouflage)" = "true" ] && echo true || echo false)" \
         "$_d4" "$_d6" "${_j_gws#,}" "${_j_cl#,}" "${_j_pools#,}" "${_j_certs#,}" \
@@ -628,6 +629,7 @@ fi
 
 hr
 echo "ocserv-server DIAG (full) : $(date -Is 2>/dev/null || date)"
+echo "Image                     : $image_version (built $image_build_date)"
 echo "Kernel                    : $(uname -r)"
 echo "ocserv version            : $(ocserv --version 2>&1 | head -1)"
 echo "Server status             : $SERVER_STATE"


### PR DESCRIPTION
`network-diagnostic` (and `docker logs`) now say what image is running. Implemented nordvpn-wg-style: build-time `safe_sed` substitution of placeholders — but into **backend-functions** rather than per script, since every script already sources it.

```
ocserv-server DIAG (full) : 2026-08-03T05:45:22+03:00
Image                     : 1.5.0-15 (built 2026-08-03 09:00:00 UTC)
```

- **CI unchanged** — it already passes both args to dev and prod builds: tag builds get the version number, main gets `dev`, other branches their sanitized name.
- **Local builds get `N/A`** (the ARG defaults), and a repo script bind-mounted over the image copy (unsubstituted placeholder) also falls back to `N/A` instead of printing `__IMAGE_VERSION__`.
- The substitution is the rootfs stage's **last layer**, so per-build values invalidate no package cache (the final stage's apk layer keys on nothing version-dependent).
- Consumers: diag header line, `--json` gains `"image":{"version":…,"built":…}`, and `init-config` logs a one-line startup banner so every `docker logs` begins with the image identity.

## Testing
- `safe_sed` exercised under busybox sh with a space-containing date and a hyphenated branch name (delimiter scan picks `/`).
- Stub harness: unsubstituted placeholder → `Image : N/A (built N/A)`; substituted copy → real values; `--json` validates with the new object.
- End-to-end proof after merge: the dev image should log and report `dev (built <timestamp>)`.