### PR TITLE
docs: openconnect-client companion image

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 OpenConnect VPN server ([ocserv](https://ocserv.gitlab.io/www/)) in a small self-configuring Docker container: it builds ocserv from source on Alpine, sets up NAT/forwarding automatically with nftables, and can disguise itself as an ordinary HTTPS website.
 
 > **Chaining through a commercial VPN?** The companion images [**azinchen/nordvpn**](https://github.com/azinchen/nordvpn) (OpenVPN) and [**azinchen/nordvpn-wg**](https://github.com/azinchen/nordvpn-wg) (WireGuard) plug straight into this server's gateway mode — your clients connect to your OpenConnect server and exit with NordVPN's IP.
+>
+> **Need the client side in Docker too?** [**azinchen/openconnect-client**](https://github.com/azinchen/openconnect-client) is the companion client: it connects to this server (camouflage supported, fail-closed kill switch included) and routes other containers (`network_mode: service:vpn`) or whole LAN hosts through the tunnel — including server-to-server cascades, where it feeds another ocserv node's gateway mode.
 
 ## ✨ Key Features
 
@@ -89,6 +91,7 @@ You provide an `ocserv.conf` and a certificate in the config volume — ready-to
 | Give each user a different exit country | [Per-user gateways][wiki-peruser] |
 | Route by destination (country direct, streaming via US, ads blocked) | [Destination Bypass][wiki-bypass] |
 | Connect phones, laptops, routers | [Clients and Devices][wiki-clients] |
+| Route other containers or LAN hosts through this server | [openconnect-client](https://github.com/azinchen/openconnect-client) (companion image) |
 
 For example, chaining every client out through a NordVPN container is just:
 

--- a/wiki/Clients-and-Devices.md
+++ b/wiki/Clients-and-Devices.md
@@ -112,6 +112,33 @@ GL.iNet-specific caveats:
 - The GL dashboard's VPN status, kill switch and "VPN policies" only apply to tunnels created in the GL UI — they **don't see** this connection. Manage it from LuCI, and don't rely on the GL kill switch for it.
 - A **firmware upgrade removes manually-installed packages** (your `/etc/config/network` settings survive with "keep settings"); rerun the `opkg install` afterwards.
 
+## Docker: openconnect-client (companion image)
+
+[**azinchen/openconnect-client**](https://github.com/azinchen/openconnect-client) is this server's companion client image — the same configuration style, built and documented alongside. Use it when the "client" is not a person's device but infrastructure:
+
+- **Route other containers** through the tunnel: they join with `network_mode: service:vpn` and transparently use it.
+- **Gateway for LAN hosts** (macvlan/routed setups) with daemon-free DNS interception.
+- **Server-to-server cascades**: an openconnect-client sidecar connects to a *remote* ocserv node and becomes a named gateway in the local node's [[Gateway Mode]] — that's how a multi-hop chain of ocserv servers is built.
+
+It speaks to this server natively — camouflage secret in the URL (redacted in logs), TCP-only friendly, `;`-separated server list for failover — and ships its own fail-closed dual-stack kill switch, installed before the client starts:
+
+```yaml
+services:
+  vpn:
+    image: azinchen/openconnect-client:latest
+    cap_add: [NET_ADMIN]
+    devices: [/dev/net/tun]
+    environment:
+      - URL=https://vpn.example.com:443/?your-secret
+      - USER=alice
+      - PASS=S3cret
+  app:
+    image: nginx:alpine
+    network_mode: service:vpn      # all of app's traffic uses the tunnel
+```
+
+Full documentation: the [openconnect-client wiki](https://github.com/azinchen/openconnect-client/wiki).
+
 ## Confirming a client really works
 
 Authenticating is not the same as carrying traffic. After connecting:

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -24,6 +24,9 @@ Yes — that's [[Gateway Mode]]: point `VPN_GATEWAY` at an upstream VPN containe
 **Can some destinations skip the upstream — or use a different one, or be blocked?**
 Yes — [[Destination Bypass]]: named CIDR pools (e.g. a country list) whose matched traffic goes direct, out a chosen gateway, or is rejected, per pool. Lists can be auto-fetched and hot-reloaded.
 
+**Is there a client for Docker — to route other containers or a LAN through this server?**
+Yes — the companion [azinchen/openconnect-client](https://github.com/azinchen/openconnect-client) image: containers join it with `network_mode: service:vpn`, LAN hosts can use it as a gateway, and it ships its own fail-closed kill switch. It also plugs into another ocserv node's [[Gateway Mode]] for server-to-server cascades. See [Clients and Devices#docker-openconnect-client-companion-image](Clients-and-Devices#docker-openconnect-client-companion-image).
+
 **Can SWAG reverse-proxy the VPN?**
 No — the VPN protocol isn't a proxyable HTTP stream. SWAG only provides the TLS certificate; ocserv is exposed directly on its own port. See [[Reverse Proxy and Certificates]].
 

--- a/wiki/Gateway-Mode.md
+++ b/wiki/Gateway-Mode.md
@@ -227,6 +227,8 @@ It has its own page: **[[Destination Bypass]]**.
 
 Whatever the upstream container is, it must **forward the Docker subnet out its tunnel** — ocserv SNATs clients to its own Docker-network address before handing packets over, so the upstream sees Docker-subnet sources and needs no route back to the client subnet. With the companion [NordVPN image](https://github.com/azinchen/nordvpn) that's one variable: `FORWARD_FROM=<docker network subnet>` (the Docker network, **not** the client subnet).
 
+The upstream doesn't have to be a commercial VPN: an [**openconnect-client**](https://github.com/azinchen/openconnect-client) sidecar connecting to a *remote* ocserv node works the same way (its gateway mode forwards the Docker subnet) — that's how **server-to-server cascades** are built, with each remote node appearing here as a named gateway.
+
 Complete compose files: **[One Upstream for All](Example-Gateway-Single-Upstream)** · **[Per-User Gateways](Example-Gateway-Per-User)**.
 
 ## Verify


### PR DESCRIPTION
The client half of the pair was nowhere in this repo's docs. Added:

- README: companion-images note (next to the nordvpn ones) and a
  Common Setups row for routing containers/LAN hosts through this
  server;
- Clients and Devices: a Docker section with a minimal compose
  (network_mode: service:vpn pattern, camouflage URL, kill switch)
  and the cascade role;
- Gateway Mode, upstream requirements: the upstream can be an
  openconnect-client sidecar connecting to a remote ocserv node -
  the server-to-server cascade building block;
- FAQ entry pointing at all of the above.
